### PR TITLE
th06.ksy: Remove not encrypted header data

### DIFF
--- a/ref/threp-ksy/th06.ksy
+++ b/ref/threp-ksy/th06.ksy
@@ -20,20 +20,6 @@ types:
     doc: blank type
   header:
     seq:
-      - id: magic
-        contents: T6RP
-      - id: version
-        size: 2
-      - id: shot
-        type: u1
-      - id: difficulty
-        type: u1
-      - id: checksum
-        type: u4
-      - id: unknown_1
-        type: u2
-      - id: ke
-        type: u1
       - id: unknown_2
         type: u1
       - id: date


### PR DESCRIPTION
Because of the way _th06_decrypt works and is called. I'd like to have _decrypt and _unlzss also work that way