### PR TITLE
Use the "bcrypt" algorithm to hash passwords.

### DIFF
--- a/project/thscoreboard/thscoreboard/settings.py
+++ b/project/thscoreboard/thscoreboard/settings.py
@@ -158,6 +158,14 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.ScryptPasswordHasher',
+]
+
 AUTH_USER_MODEL = 'users.User'
 
 # Internationalization

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ﻿asgiref==3.5.2
 attrs==22.1.0
+bcrypt==4.0.0
 bidict==0.22.0
 certifi==2022.6.15
 charset-normalizer==2.1.1


### PR DESCRIPTION
bcrypt has an excellent reputation for safety, and has become the default
choice for a password algorithm. As such, we might as well use it. This
actually will not make existing passwords obsolete; rather, they will be
rehashed to use bcrypt when the user next logs in.