### PR TITLE
Fix bugs around is_good.

### DIFF
--- a/project/thscoreboard/replays/templates/replays/replay_details.html
+++ b/project/thscoreboard/replays/templates/replays/replay_details.html
@@ -7,8 +7,8 @@
         Total score: <span class="replay-points">{{ replay.points }}</span>
     </div>
     <div>
-    {% if replay %}
-    {% if replay.is_good %}
+    {% if has_replay_file %}
+    {% if replay_file_is_good %}
         <a href="/replays/{{ game_id }}/{{ replay.id }}/download">Download replay</a>
     {% else %}
         <div>Be aware, this replay desyncs!</div>

--- a/project/thscoreboard/replays/views.py
+++ b/project/thscoreboard/replays/views.py
@@ -216,7 +216,10 @@ def replay_details(request, game_id: str, replay_id: int):
         'is_owner': request.user == replay_instance.user,
     }
     if hasattr(replay_instance, 'replayfile'):
-        context['replay'] = replay_instance.replayfile
+        context['has_replay_file'] = True
+        context['replay_file_is_good'] = replay_instance.replayfile.is_good
+    else:
+        context['has_replay_file'] = False
 
     return render(request, 'replays/replay_details.html', context)
 
@@ -388,8 +391,7 @@ def PublishReplayWithoutFile(user, difficulty: int, shot: models.Shot, points: i
         points=points,
         category=category,
         comment=comment,
-        video_link=video_link,
-        is_good=True
+        video_link=video_link
     )
     replay_instance.save()
     return replay_instance


### PR DESCRIPTION
This fixes the following bugs:
- fileless replays couldn't be uploaded
- fileless replays displayed a desync error

I think part of the root cause was a context collision: previously
"score" and "replay" were different in the view context, but they
became "replay" and "replay" and collided. But I think other parts
were always broken.