### PR TITLE
"Make the forms look a bit nicer" now with tables

### DIFF
--- a/project/thscoreboard/replays/templates/replays/base_publish_replay.html
+++ b/project/thscoreboard/replays/templates/replays/base_publish_replay.html
@@ -2,45 +2,79 @@
 
 {% block content %}
 {% block pre_replay_form %}{% endblock %}
-<form method="post" class="form-flex">
+<form method="post">
     {% csrf_token %}
     {{ form.non_field_errors }}
 
-    <div class="form-body" style="max-width: 30em;">
-    <div class="form-block">
-        {{ form.difficulty.errors }}
-        <label for="{{form.difficulty.id_for_label}}">Difficulty</label>
-        {{ form.shot.errors }}
-        <label for="{{form.shot.id_for_label}}">Shot</label>
-        {{ form.points.errors }}
-        <label for="{{form.points.id_for_label}}">Score</label>
-        {{ form.category.errors }}
-        <label for="{{form.category.id_for_label}}">Category</label>
-        {{ form.video_link.errors }}
-        <label for="{{form.video_link.id_for_label}}">Video link</label>
-
-        {% if has_replay_file %}
-        {{ form.is_good.errors }}
-        <label for="{{form.is_good.id_for_label}}">No desyncs</label>
-        {% endif %}
-        
-        {{ form.comment.errors }}
-        <label for="{{form.comment.id_for_label}}">Comment</label>
-    </div>
-    
-    <div class="form-block">
-        {{ form.difficulty }}
-        {{ form.shot }}
-        {{ form.points }} 
-        {{ form.category }} 
-        {{ form.video_link }}
+    <table class="form-table">
+        <th style="width: 50%;"></th>
+        <tr>
+        <td>
+            <label for="{{form.difficulty.id_for_label}}">Difficulty</label>
+            {{ form.difficulty.errors }}
+        </td>
+        <td>
+            {{ form.difficulty }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{form.shot.id_for_label}}">Shot</label>
+            {{ form.shot.errors }}
+        </td>
+        <td>
+            {{ form.shot }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{form.points.id_for_label}}">Score</label>
+            {{ form.points.errors }}
+        </td>
+        <td>
+            {{ form.points }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{form.category.id_for_label}}">Category</label>
+            {{ form.category.errors }}
+        </td>
+        <td>
+            {{ form.category }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{form.video_link.id_for_label}}">Video link</label>
+            {{ form.video_link.errors }}
+        </td>
+        <td>
+            {{ form.video_link }}
+        </td>
+        </tr>
     {% if has_replay_file %}
-        {{ form.is_good }}
-    {% endif %}        
-        {{ form.comment }}
-    </div>
-    </div>
-    <input type="submit" value="Publish Replay" style="margin-top: 5px; max-width: 100px;">
+        <tr>
+        <td>
+            <label for="{{form.is_good.id_for_label}}">No desyncs</label>
+            {{ form.is_good.errors }}
+        </td>
+        <td>
+            {{ form.is_good }}
+        </td>
+        </tr>
+    {% endif %}
+        <tr>
+        <td>
+            <label for="{{form.comment.id_for_label}}">Comment</label>
+            {{ form.comment.errors }}
+        </td>
+        <td>
+            {{ form.comment }}
+        </td>
+        </tr>
+    </table>
+    <input type="submit" value="Publish Replay">
 </form>
 {% block post_replay_form %}{% endblock %}
 {% endblock %}

--- a/project/thscoreboard/shared_content/static/style.sass
+++ b/project/thscoreboard/shared_content/static/style.sass
@@ -91,29 +91,15 @@ h3
 #simple-centered-content form
     text-align: left
 
-.form-flex
-    display: flex
-    flex-direction: column
-
-.form-body
-    display: flex
-    justify-content: space-between
-    flex-direction: row
-
-.form-body-profile
-    max-width: 20em
-
-.form-block
-    display: flex
-    justify-content: space-evenly
-    flex-direction: column
-
 table
     table-layout: fixed
     border-collapse: collapse
 
 th, td
     padding: 2px 5px 2px
+
+.form-table tbody
+    vertical-align: top
 
 .replay-table
     thead

--- a/project/thscoreboard/users/templates/registration/login.html
+++ b/project/thscoreboard/users/templates/registration/login.html
@@ -4,23 +4,32 @@
 
 {% block centered-content %}
 
-<form method="post" class="form-flex">
+<form method="post">
     {% csrf_token %}
     {{ form.non_field_errors }}
-
-    <div class="form-body">
-    <div class="form-block">
-        {{ form.username.errors }}
-        <label for="{{ form.username.id_for_label }}">Username</label>
-        {{ form.password.errors }}
-        <label for="{{ form.password.id_for_label }}">Password</label>
-    </div>
-    <div class="form-block">
-        {{ form.username }}
-        {{ form.password }}
-    </div>
-    </div>
-    <input type="submit" value="Log in" style="margin-top: 5px; max-width: 75px;">
+    
+    <table class="form-table">
+        <th style="width: 100%;"></th>
+        <tr>
+        <td>
+            <label for="{{ form.username.id_for_label }}">Username</label>
+            {{ form.username.errors }}
+        </td>
+        <td>
+            {{ form.username }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{ form.password.id_for_label }}">Password</label>
+            {{ form.password.errors }}
+        </td>
+        <td>
+            {{ form.password }}
+        </td>
+        </tr>
+    </table>
+    <input type="submit" value="Log in">
 </form>
 
 <p>Forgot your password? <a href="{% url 'users:forgot_password' %}">Reset it here</a>.</p>

--- a/project/thscoreboard/users/templates/registration/password_reset_confirm.html
+++ b/project/thscoreboard/users/templates/registration/password_reset_confirm.html
@@ -10,20 +10,29 @@
 
 <form method="post">{% csrf_token %}
 <fieldset class="module aligned">
-    <input type="hidden" autocomplete="username" value="{{ form.user.get_username }}">
-    <div class="form-body">
-    <div class="form-block">
-        {{ form.new_password1.errors }}
+<input type="hidden" autocomplete="username" value="{{ form.user.get_username }}">
+<table class="form-table">
+    <th style="width: 100%;"></th>
+    <tr>
+    <td>
         <label for="id_new_password1">New password:</label>
-        {{ form.new_password2.errors }}
-        <label for="id_new_password2">Confirm password:</label>
-    </div>
-    <div class="form-block">
-        {{ form.new_password1 }}       
-        {{ form.new_password2 }}
-    </div>
-    </div>
-    <input type="submit" value="Change my password" style="margin-top: 5px;">
+        {{ form.new_password1.errors }}
+    </td>
+    <td>
+        {{ form.new_password1 }}
+    </td>
+    </tr>
+    <tr>
+    <td>
+    <label for="id_new_password2">Confirm password:</label>
+    {{ form.new_password2.errors }}
+    </td>
+    <td>
+    {{ form.new_password2 }}
+    </td>
+    </tr>
+</table>
+<input type="submit" value="Change my password">
 </fieldset>
 </form>
 

--- a/project/thscoreboard/users/templates/users/profile.html
+++ b/project/thscoreboard/users/templates/users/profile.html
@@ -7,18 +7,35 @@
 <form method="post" class="form-flex">
     {% csrf_token %}
 
-    <div class="form-body form-body-profile">
-        <div class="form-block">
+    <table class="form-table">
+    <tbody>
+        <th style="width: 50%;"></th>
+        <tr>
+        <td>
             <label for="{{form.username.id_for_label}}">{{form.username.label}}</label>
-            <label for="{{form.password.id_for_label}}">{{form.password.label}}</label>
-            <label for="{{form.email.id_for_label}}">{{form.email.label}}</label>
-        </div>
-        <div class="form-block">
+        </td>
+        <td>
             {{ form.username }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{form.password.id_for_label}}">{{form.password.label}}</label>
+        </td>
+        <td>
             {{ form.password }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{form.email.id_for_label}}">{{form.email.label}}</label>
+        </td>
+        <td>
             {{ form.email }}
-        </div>
-    </div>
+        </td>
+        </tr>
+    </tbody>
+    </table>
 </form>
 
 {% endblock %}

--- a/project/thscoreboard/users/templates/users/register.html
+++ b/project/thscoreboard/users/templates/users/register.html
@@ -3,40 +3,51 @@
 {% block centered-title %}<p>Register</p>{% endblock %}
 
 {% block centered-content %}
-<form method="post" class="form-flex">
-    {% csrf_token %}
+<form method="post">
+    {% csrf_token %} 
     {{ form.non_field_errors }}
-    <div class="form-body">
-    
-    <div class="form-block">
-        {{ form.username.errors }}
-        <label for="{{ form.username.id_for_label }}">Username</label>
-        <br>
-        
-        {{ form.email.errors }}
-        <label for="{{ form.email.id_for_label }}">Email Address</label>
-        <br>
-        
-        {{ form.password.errors }}
-        <label for="{{ form.password.id_for_label }}">Password</label>
-        <br>
 
-    {% if require_passcode %}
-        {{ form.passcode.errors }}
-        <label for="{{ form.passcode.id_for_label }}">Early access passcode</label>
-    {% endif %}
-    </div>
-
-    <div class="form-block">
-    {{ form.username }} <br>
-    {{ form.email }} <br>
-    {{ form.password }} <br>
-    
-    {% if require_passcode %}
-        {{ form.passcode }}
-    {% endif %}
-    </div>
-    </div>
-    <input type="submit" value="Register" style="margin-top: 5px; max-width: 75px;">
+    <table class="form-table">
+        <th style="width: 100%;"></th>
+        <tr>
+        <td>
+            <label for="{{ form.username.id_for_label }}">Username</label>
+            {{ form.username.errors }}
+        </td>
+        <td>
+            {{ form.username }}
+        </td>
+        </tr>
+        <tr>
+        <td>
+            <label for="{{ form.email.id_for_label }}">Email Address</label>
+            {{ form.email.errors }}
+        </td>
+        <td>
+            {{ form.email }}
+        </td>
+        </tr>
+        <tr>
+            <td>
+                {{ form.password.errors }}
+                <label for="{{ form.password.id_for_label }}">Password</label>
+            </td>
+            <td>
+                {{ form.password }}
+            </td>
+        </tr>
+        {% if require_passcode %}
+        <tr>
+        <td>
+            {{ form.passcode.errors }}
+            <label for="{{ form.passcode.id_for_label }}">Early access passcode</label>
+        </td>
+        <td>
+            {{ form.passcode }}
+        </td>
+        </tr>
+        {% endif %}
+    </table>
+    <input type="submit" value="Register">
 </form>
 {% endblock %}


### PR DESCRIPTION
This reverts commit d6a3ad317de79aaaf052a2d7c6724ff54307594e.

Turns out that when the amount of things on the left side is not equal to the amount of things on the right side, nothing on either side aligns with eachother. Ideally, if something extra appears on the left, it would push everything below it down and make sure it still aligns. There is a tool that does just that, *t a b l e s*. I realized this right as my previous pull request got merged but only now did I fix this