### PR TITLE
Specify a "Real Name" in the email headers

### DIFF
--- a/project/thscoreboard/users/send_email.py
+++ b/project/thscoreboard/users/send_email.py
@@ -11,7 +11,7 @@ from thscoreboard import settings
 from . import models
 
 
-_ACCOUNTS_EMAIL = 'accounts@silentselene.net'
+_ACCOUNTS_EMAIL = 'Silent Selene Accounts <accounts@silentselene.net>'
 
 
 def _GetFullyQualifiedLink(request, url_path: str):


### PR DESCRIPTION
Turns out it's pretty easy to do. The way the django documentation documents it is wrong. It's not `"Fred" <fred@example.com>`, it's `"Fred <fred@example.com>"`, but really, the way I figured it out is by looking at the headers from some email in my inbox and comparing with the Silent Selene emails