### PR TITLE
Ignore style.css, generated by sass_processor.

### DIFF
--- a/project/thscoreboard/.gitignore
+++ b/project/thscoreboard/.gitignore
@@ -16,5 +16,6 @@ tests/coverage_html/
 tests/.coverage
 build/
 tests/report/
+shared_content/static/style.css
 staticfiles
 launch.json


### PR DESCRIPTION
I am not sure if we still need compiled_static_css tbh.