### PR TITLE
Add requirements-dev.txt.

### DIFF
--- a/.github/workflows/run_python_tests.yml
+++ b/.github/workflows/run_python_tests.yml
@@ -35,8 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
     - name: Run linter
       working-directory: ./project/thscoreboard
       run: flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+flake8==5.0.4


### PR DESCRIPTION
requirements-dev.txt is a file that you can use to install both libraries used by the server and testing/local development libraries.

With the way our deployment works right now, our prod server has to know how to deploy itself, so we can't put things like the SASS compiler here. But that's OK, there's no real downside to having them be in prod.

Fixes #37