### PR TITLE
Add "admin" page to the website.

### DIFF
--- a/project/thscoreboard/replays/admin.py
+++ b/project/thscoreboard/replays/admin.py
@@ -1,3 +1,13 @@
 """Register administration hooks in this module."""
 
-# This is empty, but in the future, we might register our models here.
+from django.contrib import admin
+
+from replays import models
+
+admin.site.register(models.Game)
+admin.site.register(models.Shot)
+admin.site.register(models.Route)
+admin.site.register(models.Replay)
+admin.site.register(models.ReplayStage)
+admin.site.register(models.ReplayFile)
+admin.site.register(models.TemporaryReplayFile)

--- a/project/thscoreboard/users/admin.py
+++ b/project/thscoreboard/users/admin.py
@@ -2,5 +2,8 @@ from django.contrib import admin
 
 from . import models
 
-# Register your models here.
 admin.site.register(models.EarlyAccessPasscode)
+admin.site.register(models.User)
+admin.site.register(models.UnverifiedUser)
+admin.site.register(models.InvitedUser)
+admin.site.register(models.UserPasscodeTie)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ bidict==0.22.0
 certifi==2022.6.15
 charset-normalizer==2.1.1
 dj-database-url==1.0.0
-Django==4.1
+Django==4.1.4
 django-appconf==1.0.5
 django-compressor==4.1
 django-rosetta==0.9.8


### PR DESCRIPTION
This allows modifying rows directly if you have a superuser account.

We should only ever use this in exceedingly rare situations; notably, I don't think we should ever use it for correcting replay data that someone put in wrong. (Instead we should build a mod flow in the website itself to handle that.) But it's useful for programming fixes and stuff like that.