### PR TITLE
Make tests quieter by silencing some of the noisier ones.

### DIFF
--- a/project/thscoreboard/replays/game_fields.py
+++ b/project/thscoreboard/replays/game_fields.py
@@ -249,5 +249,5 @@ def FormatStages(game_id: str, replay_stages):
             stage.th09_p2_cpu = ""
         if stage.th09_p2_score is None:
             stage.th09_p2_score = ""
-    
+
     return new_stages

--- a/project/thscoreboard/replays/test_view_replay.py
+++ b/project/thscoreboard/replays/test_view_replay.py
@@ -5,8 +5,6 @@ from replays.testing import test_replays
 from . import game_ids
 from . import game_fields
 
-import logging
-
 
 tests = [
     (game_ids.GameIDs.TH06, 'th6_hard_1cc'),
@@ -28,21 +26,18 @@ class TestTableFields(test_case.ReplayTestCase):
 
     def testFields(self):
         for gameid, file in tests:
-            logging.info('testing game fields %s %s', gameid, file)
-            rpy = test_replays.GetRaw(file)
-            replay_info = replay_parsing.Parse(rpy)
-            fields = game_fields.GetGameField(gameid)
-            for key in fields:
-                logging.info(key)
-                logging.info(fields[key])
-                for i in range(len(replay_info.stages)):
-                    s = replay_info.stages[i]
-                    if i < len(replay_info.stages) - 1:
-                        # don't test last stage coz fields might be missing
-                        if fields[key]:
-                            self.assertIsNotNone(s[key])
-                        if not fields[key]:
-                            self.assertIsNone(s[key])
+            with self.subTest(gameid=gameid, file=file):
+                rpy = test_replays.GetRaw(file)
+                replay_info = replay_parsing.Parse(rpy)
+                fields = game_fields.GetGameField(gameid)
+                for key in fields:
+                    for (i, s) in enumerate(replay_info.stages):
+                        if i < len(replay_info.stages) - 1:
+                            # don't test last stage coz fields might be missing
+                            if fields[key]:
+                                self.assertIsNotNone(s[key], msg=f'Expected field {key} not found')
+                            if not fields[key]:
+                                self.assertIsNone(s[key], msg=f'Unexpected field {key} found')
 
 
 class TestGetPower(test_case.ReplayTestCase):
@@ -54,6 +49,6 @@ class TestGetPower(test_case.ReplayTestCase):
         self.assertEqual(game_fields.GetFormatPower(game_ids.GameIDs.TH10, 66), '3.30')
 
     def testGetFormatLives(self):
-        
+
         self.assertEqual(game_fields.GetFormatLives(game_ids.GameIDs.TH11, 5, 2), '5 (2/5)')
         self.assertEqual(game_fields.GetFormatLives(game_ids.GameIDs.TH10, 5, 2), '5')

--- a/project/thscoreboard/replays/testing/test_case.py
+++ b/project/thscoreboard/replays/testing/test_case.py
@@ -1,5 +1,7 @@
 """Defines generally useful test cases for replay tests."""
 
+import logging
+
 from django import test
 from django.contrib import auth
 
@@ -33,4 +35,11 @@ class ReplayTestCase(UserTestCase):
     """
 
     def setUp(self):
+        # Temporarily raise logging threshold to avoid log spam.
+        logger = logging.getLogger()
+        old_level = logger.level
+        logger.setLevel(logging.WARNING)
+
         setup_constant_tables.SetUpConstantTables()
+
+        logger.setLevel(old_level)


### PR DESCRIPTION
This will make it easier to notice if warnings are logged as part of the tests.