### PR TITLE
Convert timezones to UTC before serializing them.

### DIFF
--- a/project/thscoreboard/replays/create_replay.py
+++ b/project/thscoreboard/replays/create_replay.py
@@ -6,7 +6,6 @@ not with web entities like views or forms.
 
 from typing import Optional
 from django.db import transaction
-from django.utils import timezone
 
 from replays import models
 from replays import replay_parsing
@@ -61,9 +60,7 @@ def PublishNewReplay(
         is_good=is_good,
         is_clear=is_clear,
         rep_score=replay_info.score,
-        # We convert all timestamps as UTC, in order to avoid Django's own
-        # timezone coercion logic.
-        timestamp=timezone.make_aware(replay_info.timestamp),
+        timestamp=replay_info.timestamp,
         name=replay_info.name,
         route=replay_info.route,
         spell_card_id=replay_info.spell_card_id,

--- a/project/thscoreboard/replays/create_replay.py
+++ b/project/thscoreboard/replays/create_replay.py
@@ -6,6 +6,7 @@ not with web entities like views or forms.
 
 from typing import Optional
 from django.db import transaction
+from django.utils import timezone
 
 from replays import models
 from replays import replay_parsing
@@ -60,7 +61,9 @@ def PublishNewReplay(
         is_good=is_good,
         is_clear=is_clear,
         rep_score=replay_info.score,
-        timestamp=replay_info.timestamp,
+        # We convert all timestamps as UTC, in order to avoid Django's own
+        # timezone coercion logic.
+        timestamp=timezone.make_aware(replay_info.timestamp),
         name=replay_info.name,
         route=replay_info.route,
         spell_card_id=replay_info.spell_card_id,

--- a/project/thscoreboard/replays/lib/test_time.py
+++ b/project/thscoreboard/replays/lib/test_time.py
@@ -1,0 +1,15 @@
+
+import datetime
+import unittest
+
+from replays.lib import time
+
+
+class TimeTest(unittest.TestCase):
+
+    def testStrptime(self):
+        parsed_time = time.strptime('11/24/2001', '%m/%d/%Y')
+        self.assertEqual(
+            parsed_time,
+            datetime.datetime(2001, 11, 24, tzinfo=datetime.timezone.utc)
+        )

--- a/project/thscoreboard/replays/lib/time.py
+++ b/project/thscoreboard/replays/lib/time.py
@@ -1,0 +1,10 @@
+import datetime
+
+
+def strptime(date_string: str, format: str) -> datetime.datetime:
+    """Returns a datetime created from a string input.
+
+    Unlike datetime.datetime.strptime, this always returns a UTC datetime.
+    """
+
+    return datetime.datetime.strptime(date_string, format).replace(tzinfo=datetime.timezone.utc)

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -240,7 +240,11 @@ class Replay(models.Model):
     """A comment the user entered."""
 
     timestamp = models.DateTimeField(blank=True, null=True)
-    """Timestamp from the replay"""
+    """Timestamp from the replay.
+
+    Timestamps are stored in UTC. However, this may not actually reflect the
+    timestamp stored in the replay file.
+    """
 
     name = models.TextField(max_length=12, blank=True, null=True)
     """Username stored in the replay

--- a/project/thscoreboard/replays/replay_parsing.py
+++ b/project/thscoreboard/replays/replay_parsing.py
@@ -2,9 +2,10 @@
 
 from dataclasses import dataclass
 from typing import Optional
-from datetime import datetime
+import datetime
 from kaitaistruct import KaitaiStructError
 
+from replays.lib import time
 from . import game_ids
 from .kaitai_parsers import th06
 from .kaitai_parsers import th07
@@ -64,7 +65,12 @@ class ReplayInfo:
     shot: str
     difficulty: int
     score: int
-    timestamp: datetime
+    timestamp: datetime.datetime
+    """The timestamp for the replay.
+
+    This field is an aware datetime.
+    """
+
     name: str
     replay_type: int
     route: Optional[str] = None
@@ -75,6 +81,15 @@ class ReplayInfo:
     def spell_card_id_format(self):
         """Get frontend formatted spellcard id (1-indexed instead of 0-indexed)"""
         return self.spell_card_id + 1
+
+    def __post_init__(self):
+        if self.timestamp.tzinfo is None:
+            # Why require the datetime be aware?
+            # Basically, it's because Python timezone handling is a disaster.
+            # datetimes without explicit timezone info tend to be converted
+            # in weird ways by builtin methods, so it's way too easy to
+            # accidentally apply a timezone correction twice.
+            raise ValueError('timestamp datetime must be aware')
 
 
 def _Parse06(rep_raw):
@@ -125,7 +140,7 @@ def _Parse06(rep_raw):
         shot=shots[rep_raw[6]],
         difficulty=rep_raw[7],
         score=replay.header.score,
-        timestamp=datetime.strptime(replay.header.date, "%m/%d/%y"),
+        timestamp=time.strptime(replay.header.date, "%m/%d/%y"),
         name=replay.header.name.replace("\x00", ""),
         replay_type=r_type
     )
@@ -140,7 +155,7 @@ def _Parse07(rep_raw):
     td.decrypt06(comp_data, rep_raw[13])
     #   please don't ask what is going on here
     #   0x54 - 16 = 68
-    
+
     comp_size = int.from_bytes(comp_data[4:8], byteorder='little')
     replay = th07.Th07.from_bytes(bytearray(16) + comp_data[0:68] + td.unlzss(comp_data[68:68 + comp_size]))
 
@@ -198,7 +213,7 @@ def _Parse07(rep_raw):
         shot=shots[replay.header.shot],
         difficulty=replay.header.difficulty,
         score=replay.header.score * 10,
-        timestamp=datetime.strptime(replay.header.date, "%m/%d"),
+        timestamp=time.strptime(replay.header.date, "%m/%d"),
         name=replay.header.name.replace("\x00", ""),
         replay_type=r_type
     )
@@ -214,7 +229,7 @@ def _Parse08(rep_raw):
     #   basically copied from _Parse07()
     #   0x68 (104) - 24 = 80
     replay = th08.Th08.from_bytes(bytearray(24) + comp_data[0:80] + td.unlzss(comp_data[80:]))
-    
+
     shots = [
         "Reimu & Yukari",
         "Marisa & Alice",
@@ -239,7 +254,7 @@ def _Parse08(rep_raw):
             shot=shots[replay.header.shot],
             difficulty=replay.header.difficulty,
             score=replay.header.score * 10,
-            timestamp=datetime.strptime(replay.header.date, "%m/%d"),
+            timestamp=time.strptime(replay.header.date, "%m/%d"),
             name=replay.header.name.replace("\x00", ""),
             replay_type=game_ids.ReplayTypes.SPELL_PRACTICE,
             spell_card_id=replay.header.spell_card_id
@@ -296,7 +311,7 @@ def _Parse08(rep_raw):
         shot=shots[replay.header.shot],
         difficulty=replay.header.difficulty,
         score=replay.header.score * 10,
-        timestamp=datetime.strptime(replay.header.date, "%m/%d"),
+        timestamp=time.strptime(replay.header.date, "%m/%d"),
         name=replay.header.name.replace("\x00", ""),
         replay_type=r_type,
         route=route
@@ -384,7 +399,7 @@ def _Parse09(rep_raw):
 
         r_shot = shots[p1.shot]
         r_score = p1.score * 10
-        
+
         s = ReplayStage()
         s.stage = 0
         s.score = p1.score * 10
@@ -405,7 +420,7 @@ def _Parse09(rep_raw):
         shot=r_shot,
         difficulty=replay.header.difficulty,
         score=r_score,
-        timestamp=datetime.strptime(replay.header.date, "%y/%m/%d"),
+        timestamp=time.strptime(replay.header.date, "%y/%m/%d"),
         name=replay.header.name.replace("\x00", ""),
         replay_type=r_type
     )
@@ -459,7 +474,7 @@ def _Parse10(rep_raw):
         shot=shots[replay.header.shot],
         difficulty=replay.header.difficulty,
         score=replay.header.score * 10,
-        timestamp=datetime.fromtimestamp(replay.header.timestamp),
+        timestamp=datetime.datetime.fromtimestamp(replay.header.timestamp, tz=datetime.timezone.utc),
         name=replay.header.name.replace("\x00", ""),
         replay_type=r_type
     )
@@ -520,7 +535,7 @@ def _Parse11(rep_raw):
         shot=shots[replay.header.shot],
         difficulty=replay.header.difficulty,
         score=replay.header.score * 10,
-        timestamp=datetime.fromtimestamp(replay.header.timestamp),
+        timestamp=datetime.datetime.fromtimestamp(replay.header.timestamp, tz=datetime.timezone.utc),
         name=replay.header.name.replace("\x00", ""),
         replay_type=r_type
     )

--- a/project/thscoreboard/replays/test_create_replay.py
+++ b/project/thscoreboard/replays/test_create_replay.py
@@ -1,4 +1,6 @@
 
+import datetime
+
 from replays import game_ids
 from replays import models
 from replays import create_replay
@@ -79,6 +81,7 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
         self.assertEqual(new_replay.category, models.Category.REGULAR)
         self.assertEqual(new_replay.comment, 'Hello')
         self.assertEqual(new_replay.replay_type, 1)
+        self.assertEqual(new_replay.timestamp, datetime.datetime(2018, 2, 19, 4, 44, 21, tzinfo=datetime.timezone.utc))
 
         with self.assertRaises(models.TemporaryReplayFile.DoesNotExist):
             models.TemporaryReplayFile.objects.get(id=temp_replay.id)

--- a/project/thscoreboard/replays/test_create_replay.py
+++ b/project/thscoreboard/replays/test_create_replay.py
@@ -81,7 +81,7 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
         self.assertEqual(new_replay.category, models.Category.REGULAR)
         self.assertEqual(new_replay.comment, 'Hello')
         self.assertEqual(new_replay.replay_type, 1)
-        self.assertEqual(new_replay.timestamp, datetime.datetime(2018, 2, 19, 4, 44, 21, tzinfo=datetime.timezone.utc))
+        self.assertEqual(new_replay.timestamp, datetime.datetime(2018, 2, 19, 9, 44, 21, tzinfo=datetime.timezone.utc))
 
         with self.assertRaises(models.TemporaryReplayFile.DoesNotExist):
             models.TemporaryReplayFile.objects.get(id=temp_replay.id)

--- a/project/thscoreboard/replays/test_replay_parsing.py
+++ b/project/thscoreboard/replays/test_replay_parsing.py
@@ -185,7 +185,7 @@ class Th10ReplayTestCase(unittest.TestCase):
         self.assertEqual(r.name, 'AAAAAAAA')
         self.assertEqual(
             r.timestamp,
-            datetime.datetime(2018, 2, 19, 4, 44, 21)
+            datetime.datetime(2018, 2, 19, 9, 44, 21, tzinfo=datetime.timezone.utc)
         )
         self.assertEqual(r.stages[1].piv, 159660)
 

--- a/project/thscoreboard/replays/test_replay_parsing.py
+++ b/project/thscoreboard/replays/test_replay_parsing.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 
 from replays.testing import test_replays
@@ -10,7 +11,7 @@ def ParseTestReplay(filename):
 
 
 class Th06ReplayTestCase(unittest.TestCase):
-    
+
     def testHard1cc(self):
         r = ParseTestReplay('th6_hard_1cc')
         self.assertEqual(r.game, 'th06')
@@ -137,7 +138,7 @@ class Th08ReplayTestCase(unittest.TestCase):
 
 
 class Th09ReplayTestCase(unittest.TestCase):
-    
+
     def testLunatic(self):
         r = ParseTestReplay('th9_lunatic')
 
@@ -174,7 +175,7 @@ class Th09ReplayTestCase(unittest.TestCase):
 
 
 class Th10ReplayTestCase(unittest.TestCase):
-    
+
     def testNormal(self):
         r = ParseTestReplay('th10_normal')
         self.assertEqual(r.game, 'th10')
@@ -182,8 +183,12 @@ class Th10ReplayTestCase(unittest.TestCase):
         self.assertEqual(r.shot, 'ReimuB')
         self.assertEqual(r.score, 294127890)
         self.assertEqual(r.name, 'AAAAAAAA')
+        self.assertEqual(
+            r.timestamp,
+            datetime.datetime(2018, 2, 19, 4, 44, 21)
+        )
         self.assertEqual(r.stages[1].piv, 159660)
-        
+
     def testNull(self):
         with self.assertRaises(replay_parsing.BadReplayError):
             ParseTestReplay('th10_null')


### PR DESCRIPTION
This fixes an odd issue I had when working on the "reanalyze replay" function. Specifically, the way it was before, Django would only convert a naive datetime to an aware datetime when the instance was actually saved, which lead to weird issues when comparing the "old" replay row and the "updated" one. This also made Django log annoying warnings.

I am still not actually sure how Touhou itself handles timezones, though. Are the timestamps saved in replay files UTC, or are they local time?