### PR TITLE
Allow reanalysis to actually update a replay on the site.

### DIFF
--- a/project/thscoreboard/replays/reanalyze_replay.py
+++ b/project/thscoreboard/replays/reanalyze_replay.py
@@ -7,6 +7,7 @@ As this module is used only for administrative work, it is not optimized
 for speed.
 """
 
+import abc
 import copy
 from typing import Optional
 
@@ -20,20 +21,76 @@ from replays import replay_parsing
 def CheckReplay(replay_id: int) -> str:
     """Check a replay and return information about how it would be updated."""
 
+    differ = _Differ()
+    _Reanalyze(replay_id, differ)
+    return differ.GetOutput()
+
+
+class _Recorder(abc.ABC):
+    """Internal class that records a difference that happened during reanalysis."""
+
+    @abc.abstractmethod
+    def Change(self, name: str, old_model: django_models.Model, new_model: django_models.Model):
+        """Record a change to a row."""
+
+    @abc.abstractmethod
+    def New(self, name: str, new_model: django_models.Model):
+        """Record a new row."""
+
+    @abc.abstractmethod
+    def Deleted(self, name: str, old_model: django_models.Model):
+        """Record a row being deleted."""
+
+
+class _Differ(_Recorder):
+    """A Differ just records changes in text."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._output = []
+
+    def _PrefaceWithName(self, name, diff_str):
+        if not diff_str:
+            # Don't preface the empty string.
+            return ''
+        return f'{name}:\n{diff_str}'
+
+    def Change(self, name: str, old_model: django_models.Model, new_model: django_models.Model):
+        diff = _Diff(old_model, new_model)
+        if diff:
+            self._output.append(self._PrefaceWithName(name, diff))
+
+    def New(self, name: str, new_model: django_models.Model):
+        diff = _Diff(None, new_model)
+        if diff:
+            self._output.append(self._PrefaceWithName(name, diff))
+
+    def Deleted(self, name: str, old_model: django_models.Model):
+        diff = _Diff(old_model, None)
+        if diff:
+            self._output.append(self._PrefaceWithName(name, diff))
+
+    def GetOutput(self):
+        return '\n\n'.join([d for d in self._output if d])
+
+
+def _Reanalyze(replay_id: int, recorder: _Recorder) -> str:
+    """Reanalyze computed fields on a replay."""
+
     replay = models.Replay.objects.get(id=replay_id)
     replay_file = models.ReplayFile.objects.get(replay=replay)
     replay_info = replay_parsing.Parse(replay_file.replay_file)
     replay_to_update = copy.deepcopy(replay)
-    replay_diffs = []
 
     replay_to_update.SetFromReplayInfo(replay_info)
-    replay_diffs.append(_Diff(replay, replay_to_update))
+    recorder.Change('Replay', replay, replay_to_update)
 
     replay_stages = models.ReplayStage.objects.filter(replay=replay_id).order_by('stage')
     seen_stages = set()
     for replay_file_stage_info in replay_info.stages:
         matching_stages = [r for r in replay_stages
                            if r.stage == replay_file_stage_info.stage]
+        stage_name = f'Stage {replay_file_stage_info.stage}'
 
         if len(matching_stages) > 1:
             raise AssertionError(
@@ -43,7 +100,7 @@ def CheckReplay(replay_id: int) -> str:
             matching_stage = matching_stages[0]
             matching_stage_to_update = copy.deepcopy(matching_stage)
             matching_stage_to_update.SetFromReplayStageInfo(replay_file_stage_info)
-            stage_diff = _Diff(matching_stage, matching_stage_to_update)
+            recorder.Change(stage_name, matching_stage, matching_stage_to_update)
         else:
             # TODO: Deduplicate this with the real logic in create_replay.py somehow.
             new_stage = models.ReplayStage(
@@ -53,17 +110,11 @@ def CheckReplay(replay_id: int) -> str:
             if replay_info.game == game_ids.GameIDs.TH09:
                 new_stage.th09_p2_shot = models.Shot.objects.select_related('game').get(game=game_ids.GameIDs.TH09, shot_id=replay_file_stage_info.th09_p2_shot)
             new_stage.SetFromReplayStageInfo(replay_file_stage_info)
-            stage_diff = _Diff(None, new_stage)
+            recorder.New(stage_name, new_stage)
 
-        if stage_diff:
-            stage_diff = f'Stage {replay_file_stage_info.stage}:\n' + stage_diff
-            replay_diffs.append(stage_diff)
     for replay_stage in replay_stages:
         if replay_stage.stage not in seen_stages:
-            stage_diff = f'Stage {replay_stage.stage}:\n' + _Diff(replay_stage, None)
-            replay_diffs.append(stage_diff)
-
-    return '\n\n'.join([d for d in replay_diffs if d])
+            recorder.Deleted(f'Stage {replay_stage.stage}', replay_stage)
 
 
 def _GetComparableFields(m: django_models.Model):

--- a/project/thscoreboard/replays/templates/replays/reanalyze_replay.html
+++ b/project/thscoreboard/replays/templates/replays/reanalyze_replay.html
@@ -4,4 +4,8 @@
 {% block content %}
     <h2><a href="{% url 'Replays/Details' replay.shot.game.game_id replay.id %}">Back to view</a></h2>
     <pre>{{ reanalysis }}</pre>
+    <form method="POST">
+        {% csrf_token %}
+        <input type="submit" />
+    </form>
 {% endblock %}

--- a/project/thscoreboard/replays/test_reanalyze_replay.py
+++ b/project/thscoreboard/replays/test_reanalyze_replay.py
@@ -13,11 +13,24 @@ class ReanalyzeReplayTest(test_case.ReplayTestCase):
         super().setUp()
         self.user = self.createUser('some-user')
 
+    def GetNew(self, replay):
+        """Fetch a new copy of the given replay model."""
+        return models.Replay.objects.get(id=replay.id)
+
+    def AssertNoDiff(self, id):
+        self.assertEqual(reanalyze_replay.CheckReplay(id), '')
+
     def testNoDiff(self):
         replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
 
         diff = reanalyze_replay.CheckReplay(replay.id)
         self.assertEqual(diff, '')
+
+    def testNoDiff_Update(self):
+        replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
+
+        reanalyze_replay.UpdateReplay(replay.id)
+        self.assertEqual(replay, models.Replay.objects.get(id=replay.id))
 
     def testTimestampDiff(self):
         replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
@@ -30,30 +43,75 @@ class ReanalyzeReplayTest(test_case.ReplayTestCase):
             '2018-02-19T10:44:21+00:00 -> 2018-02-19T09:44:21+00:00', diff
         )
 
+    def testTimestampDiff_Update(self):
+        replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
+        real_timestamp = replay.timestamp
+
+        replay.timestamp += datetime.timedelta(hours=1)
+        replay.save()
+
+        reanalyze_replay.UpdateReplay(replay.id)
+        new_replay = self.GetNew(replay)
+
+        self.assertEqual(real_timestamp, new_replay.timestamp)
+        self.AssertNoDiff(replay.id)
+
     def testStage2Diff(self):
         replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
 
-        stage2 = models.ReplayStage.objects.get(replay=replay, stage=1)
+        stage2 = models.ReplayStage.objects.get(replay=replay, stage=2)
         stage2.piv += 100000
         stage2.save()
 
         diff = reanalyze_replay.CheckReplay(replay.id)
-        self.assertIn('Stage 1:', diff)
+        self.assertIn('Stage 2:', diff)
         self.assertIn(
-            '[piv] 214270 -> 114270', diff
+            '[piv] 259660 -> 159660', diff
         )
+
+    def testStage2Diff_Update(self):
+        replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
+
+        stage2 = models.ReplayStage.objects.get(replay=replay, stage=2)
+        stage2_piv = stage2.piv
+        stage2.piv += 100000
+        stage2.save()
+
+        reanalyze_replay.UpdateReplay(replay.id)
+        new_stage2 = models.ReplayStage.objects.get(replay=replay, stage=2)
+        self.assertEqual(new_stage2.stage, 2)
+        self.assertEqual(stage2_piv, new_stage2.piv)
+
+        self.AssertNoDiff(replay.id)
 
     def testStage2Missing(self):
         replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
 
-        stage2 = models.ReplayStage.objects.get(replay=replay, stage=1)
+        stage2 = models.ReplayStage.objects.get(replay=replay, stage=2)
         stage2.delete()
 
         diff = reanalyze_replay.CheckReplay(replay.id)
-        self.assertIn('Stage 1:', diff)
+        self.assertIn('Stage 2:', diff)
         self.assertIn(
-            '[piv] (No model!) -> 114270', diff
+            '[piv] (No model!) -> 159660', diff
         )
+
+    def testStage2Missing_Update(self):
+        replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
+
+        old_stages = list(models.ReplayStage.objects.filter(replay=replay).order_by('stage'))
+        stage2 = old_stages[1]
+        self.assertEqual(stage2.stage, 2)
+        stage2_piv = stage2.piv
+        stage2.delete()
+
+        reanalyze_replay.UpdateReplay(replay.id)
+        new_stages = models.ReplayStage.objects.filter(replay=replay).order_by('stage')
+        self.assertEqual(len(new_stages), 6)
+        self.assertEqual(new_stages[1].stage, 2)
+        self.assertEqual(new_stages[1].piv, stage2_piv)
+
+        self.AssertNoDiff(replay.id)
 
     def testStage9(self):
         replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
@@ -64,3 +122,13 @@ class ReanalyzeReplayTest(test_case.ReplayTestCase):
         diff = reanalyze_replay.CheckReplay(replay.id)
         self.assertIn('Stage 8:', diff)
         self.assertIn('[piv] 999999 -> (No model!)', diff)
+
+    def testStage9_Update(self):
+        replay = test_replays.CreateAsPublishedReplay('th10_normal', self.user)
+
+        fake_stage_9 = models.ReplayStage(replay=replay, stage=9, piv=999999)
+        fake_stage_9.save()
+
+        reanalyze_replay.UpdateReplay(replay.id)
+        with self.assertRaises(models.ReplayStage.DoesNotExist):
+            models.ReplayStage.objects.get(replay=replay, stage=9)


### PR DESCRIPTION
This change adds a button to the /reanalyze hidden route that updates the replay in question.

This way, if we change how derived fields are set on a replay, we can use this to update old replays. This is still not really what we want for #105 (what we want is to reparse all replays), but it's close; now that we have this it should be easy to finish that one off.