### PR TITLE
Allow the site to respond to traffic from local.silentselene.net.

### DIFF
--- a/project/thscoreboard/thscoreboard/settings.py
+++ b/project/thscoreboard/thscoreboard/settings.py
@@ -40,7 +40,7 @@ DEBUG = not IS_PROD
 
 
 def _GetAllowedHosts():
-    hosts = ['localhost']
+    hosts = ['localhost', 'local.silentselene.net']
     env_host = os.environ.get('MY_HOST')
     if env_host:
         hosts.append(env_host)


### PR DESCRIPTION
This address is just 127.0.0.1, but I think it can be more convenient to access this way.