### PR TITLE
Ignore the .vscode directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 LOCAL_NOTES
+.vscode


### PR DESCRIPTION
This directory stores local configuration changes with Visual Studio Code. It should not be checked in.