### PR TITLE
Run "compilemessages" as part of the deploy process.

### DIFF
--- a/project/thscoreboard/thscoreboard/deploy/deploy.py
+++ b/project/thscoreboard/thscoreboard/deploy/deploy.py
@@ -33,6 +33,10 @@ def update_and_deploy(user: str):
         )
 
         management.call_command(
+            'compilemessages',
+        )
+
+        management.call_command(
             'collectstatic',
             interactive=False
         )


### PR DESCRIPTION
This command compiles the already-written translation definitions.

I think not doing this was the cause of #202.