### PR TITLE
Refactor: Make use of next stage explicit

### DIFF
--- a/project/thscoreboard/replays/replay_parsing.py
+++ b/project/thscoreboard/replays/replay_parsing.py
@@ -106,34 +106,26 @@ def _Parse06(rep_raw):
     shots = ["ReimuA", "ReimuB", "MarisaA", "MarisaB"]
 
     rep_stages = []
-    for i, score in enumerate(replay.stages):
-        if replay.header.stage_offsets[i] != 0:
-            s = ReplayStage()
-            s.stage = i + 1
-            s.score = score.score
-            s.power = score.power
-            s.lives = score.lives
-            s.bombs = score.bombs
-            s.th06_rank = score.rank
-            rep_stages.append(s)
 
-    # adjust stage data to be end-of-stage
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            """not the end yet"""
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
+    enumerated_non_dummy_stages = [
+        (i, _stage)
+        for i, _stage in enumerate(replay.stages)
+        if replay.header.stage_offsets[i] != 0
+    ]
+    for (i, current_stage), (j, next_stage) in zip(
+        enumerated_non_dummy_stages, enumerated_non_dummy_stages[1:] + [(None, None)]
+    ):
+        s = ReplayStage(
+            stage=i + 1,
+            score=current_stage.score
+        )
+        if next_stage is not None:
+            s.power = next_stage.power
+            s.lives = next_stage.lives
+            s.bombs = next_stage.bombs
+            s.th06_rank = next_stage.rank
 
-            stage.power = next_stage.power
-            stage.lives = next_stage.lives
-            stage.bombs = next_stage.bombs
-            stage.th06_rank = next_stage.th06_rank
-        else:
-            stage = rep_stages[i]
-            stage.power = None
-            stage.lives = None
-            stage.bombs = None
-            stage.th06_rank = None
+        rep_stages.append(s)
 
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and rep_raw[7] != 4:
@@ -167,49 +159,33 @@ def _Parse07(rep_raw):
 
     rep_stages = []
 
+    enumerated_non_dummy_stages = [
+        (i, _stage)
+        for i, _stage in enumerate(replay.stages)
+        if replay.file_header.stage_offsets[i] != 0
+    ]
+
     def is_phantasm(difficulty_code: int) -> bool:
         return difficulty_code == 5
 
-    for i, score in enumerate(replay.stages):
-        if replay.file_header.stage_offsets[i] != 0:
-            s = ReplayStage()
-            s.stage = i + 1
-            if is_phantasm(replay.header.difficulty):
-                s.stage = i + 2
-            s.score = score.score * 10
-            s.power = score.power
-            s.lives = score.lives
-            s.bombs = score.bombs
-            s.point_items = score.point_items
-            s.graze = score.graze
-            s.piv = score.piv
-            s.th07_cherry = score.cherry
-            s.th07_cherrymax = score.cherrymax
-            rep_stages.append(s)
+    for (i, current_stage), (j, next_stage) in zip(
+        enumerated_non_dummy_stages, enumerated_non_dummy_stages[1:] + [(None, None)]
+    ):
+        s = ReplayStage(
+            stage=i + 2 if is_phantasm(replay.header.difficulty) else i + 1,
+            score=current_stage.score * 10
+        )
+        if next_stage is not None:
+            s.power = next_stage.power
+            s.piv = next_stage.piv
+            s.lives = next_stage.lives
+            s.bombs = next_stage.bombs
+            s.graze = next_stage.graze
+            s.point_items = next_stage.point_items
+            s.th07_cherry = next_stage.cherry
+            s.th07_cherrymax = next_stage.cherrymax
 
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
-
-            stage.power = next_stage.power
-            stage.lives = next_stage.lives
-            stage.bombs = next_stage.bombs
-            stage.point_items = next_stage.point_items
-            stage.graze = next_stage.graze
-            stage.piv = next_stage.piv
-            stage.th07_cherry = next_stage.th07_cherry
-            stage.th07_cherrymax = next_stage.th07_cherrymax
-        else:
-            stage = rep_stages[i]
-            stage.power = None
-            stage.lives = None
-            stage.bombs = None
-            stage.point_items = None
-            stage.graze = None
-            stage.piv = None
-            stage.th07_cherry = None
-            stage.th07_cherrymax = None
+        rep_stages.append(s)
 
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and replay.header.difficulty not in [4, 5]:
@@ -277,42 +253,32 @@ def _Parse08(rep_raw):
     #   else regular run
 
     route = None
-    for i, score in enumerate(replay.stages):
-        if replay.file_header.stage_offsets[i] != 0:
-            s = ReplayStage()
-            s.stage = i + 1
-            s.score = score.score * 10
-            s.power = score.power
-            s.lives = score.lives
-            s.bombs = score.bombs
-            s.point_items = score.point_items
-            s.graze = score.graze
-            s.piv = score.piv
-            if i == 6:
-                route = 'Final A'
-            elif i == 7:
-                route = 'Final B'
-            rep_stages.append(s)
+    enumerated_non_dummy_stages = [
+        (i, _stage)
+        for i, _stage in enumerate(replay.stages)
+        if replay.file_header.stage_offsets[i] != 0
+    ]
+    for (i, current_stage), (j, next_stage) in zip(
+        enumerated_non_dummy_stages, enumerated_non_dummy_stages[1:] + [(None, None)]
+    ):
+        s = ReplayStage(
+            stage=i + 1,
+            score=current_stage.score * 10,
+        )
+        if next_stage is not None:
+            s.power = next_stage.power
+            s.piv = next_stage.piv
+            s.lives = next_stage.lives
+            s.bombs = next_stage.bombs
+            s.graze = next_stage.graze
+            s.point_items = next_stage.point_items
+            
+        if i == 6:
+            route = 'Final A'
+        elif i == 7:
+            route = 'Final B'
 
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
-
-            stage.power = next_stage.power
-            stage.lives = next_stage.lives
-            stage.bombs = next_stage.bombs
-            stage.point_items = next_stage.point_items
-            stage.graze = next_stage.graze
-            stage.piv = next_stage.piv
-        else:
-            stage = rep_stages[i]
-            stage.power = None
-            stage.lives = None
-            stage.bombs = None
-            stage.point_items = None
-            stage.graze = None
-            stage.piv = None
+        rep_stages.append(s)
 
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and replay.header.difficulty != 4:
@@ -366,7 +332,8 @@ def _Parse09(rep_raw):
 
     highest_stage = 0
     if replay.file_header.stage_offsets[9] == 0:
-        #   story mode
+        #  story mode
+        #  collect start-of-stage data
         for i in range(9):
             if replay.file_header.stage_offsets[i] != 0:
                 #   real stage
@@ -386,11 +353,12 @@ def _Parse09(rep_raw):
                 highest_stage = i
                 rep_stages.append(s)
 
-            #   fill in replayinfo
+            #  fill in replayinfo
             p1 = replay.stages[highest_stage]
             r_shot = shots[p1.shot]
             r_score = p1.score * 10
 
+        #  adjust stage data to be end-of-stage
         for i in range(len(rep_stages)):
             if i < len(rep_stages) - 1:
                 stage = rep_stages[i]
@@ -453,30 +421,21 @@ def _Parse10(rep_raw):
     shots = ["ReimuA", "ReimuB", "ReimuC", "MarisaA", "MarisaB", "MarisaC"]
 
     rep_stages = []
-    for stage in replay.stages:
-        s = ReplayStage()
-        s.stage = stage.stage_num
-        s.score = stage.score * 10
-        s.power = stage.power
-        s.piv = stage.piv * 10
-        s.lives = stage.lives
-        rep_stages.append(s)
-
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
-
-            stage.score = next_stage.score
-            stage.power = next_stage.power
-            stage.piv = next_stage.piv
-            stage.lives = next_stage.lives
+    
+    for current_stage, next_stage in zip(
+        replay.stages, replay.stages[1:] + [None]
+    ):
+        s = ReplayStage(
+            stage=current_stage.stage_num,
+        )
+        if next_stage is not None:
+            s.score = next_stage.score * 10
+            s.power = next_stage.power
+            s.piv = next_stage.piv * 10
+            s.lives = next_stage.lives
         else:
-            stage = rep_stages[i]
-            stage.score = replay.header.score * 10
-            stage.power = None
-            stage.piv = None
-            stage.lives = None
+            s.score = replay.header.score * 10
+        rep_stages.append(s)
 
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and replay.header.difficulty != 4:
@@ -508,36 +467,23 @@ def _Parse11(rep_raw):
     shots = ["ReimuA", "ReimuB", "ReimuC", "MarisaA", "MarisaB", "MarisaC"]
 
     rep_stages = []
-    for stage in replay.stages:
-        s = ReplayStage()
-        s.stage = stage.stage_num
-        s.score = stage.score * 10
-        s.piv = stage.piv
-        s.graze = stage.graze
-        s.power = stage.power
-        s.lives = stage.lives
-        s.life_pieces = stage.life_pieces
-        rep_stages.append(s)
 
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
-
-            stage.score = next_stage.score
-            stage.piv = next_stage.piv
-            stage.graze = next_stage.graze
-            stage.power = next_stage.power
-            stage.lives = next_stage.lives
-            stage.life_pieces = next_stage.life_pieces
+    for current_stage, next_stage in zip(
+        replay.stages, replay.stages[1:] + [None]
+    ):
+        s = ReplayStage(
+            stage=current_stage.stage_num,
+        )
+        if next_stage is not None:
+            s.score = next_stage.score * 10
+            s.power = next_stage.power
+            s.piv = next_stage.piv
+            s.lives = next_stage.lives
+            s.life_pieces = next_stage.life_pieces
+            s.graze = next_stage.graze
         else:
-            stage = rep_stages[i]
-            stage.score = replay.header.score * 10
-            stage.piv = None
-            stage.graze = None
-            stage.power = None
-            stage.lives = None
-            stage.life_pieces = None
+            s.score = replay.header.score * 10
+        rep_stages.append(s)
 
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and replay.header.difficulty != 4:
@@ -569,45 +515,28 @@ def _Parse12(rep_raw):
     shots = ["ReimuA", "ReimuB", "MarisaA", "MarisaB", "SanaeA", "SanaeB"]
 
     rep_stages = []
-    for stage in replay.stages:
-        s = ReplayStage()
-        s.stage = stage.stage_num
-        s.score = stage.score * 10
-        s.power = stage.power
-        s.piv = (math.trunc(stage.piv / 1000)) * 10
-        s.lives = stage.lives
-        s.life_pieces = stage.life_pieces
-        #   fix zun fuckery
-        if s.life_pieces > 0:
-            s.life_pieces -= 1
-        s.bombs = stage.bombs
-        s.bomb_pieces = stage.bomb_pieces
-        s.graze = stage.graze
-        rep_stages.append(s)
 
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
-
-            stage.score = next_stage.score
-            stage.power = next_stage.power
-            stage.piv = next_stage.piv
-            stage.lives = next_stage.lives
-            stage.life_pieces = next_stage.life_pieces
-            stage.bombs = next_stage.bombs
-            stage.bomb_pieces = next_stage.bomb_pieces
-            stage.graze = next_stage.graze
+    for current_stage, next_stage in zip(
+        replay.stages, replay.stages[1:] + [None]
+    ):
+        s = ReplayStage(
+            stage=current_stage.stage_num,
+        )
+        if next_stage is not None:
+            s.score = next_stage.score * 10
+            s.power = next_stage.power
+            s.piv = (math.trunc(next_stage.piv / 1000)) * 10
+            s.lives = next_stage.lives
+            s.life_pieces = next_stage.life_pieces
+            #   fix zun fuckery
+            if s.life_pieces > 0:
+                s.life_pieces -= 1
+            s.bombs = next_stage.bombs
+            s.bomb_pieces = next_stage.bomb_pieces
+            s.graze = next_stage.graze
         else:
-            stage = rep_stages[i]
-            stage.score = replay.header.score * 10
-            stage.power = None
-            stage.piv = None
-            stage.lives = None
-            stage.life_pieces = None
-            stage.bombs = None
-            stage.bomb_pieces = None
-            stage.graze = None
+            s.score = replay.header.score * 10
+        rep_stages.append(s)
 
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and replay.header.difficulty != 4:
@@ -653,49 +582,28 @@ def _Parse13(rep_raw):
             spell_card_id=replay.header.spell_practice_id
         )
 
-    for stage in replay.stages:
-        s = ReplayStage()
-        s.stage = stage.stage_num
-        s.score = stage.score * 10
-        s.power = stage.power
-        s.piv = (math.trunc(stage.piv / 1000)) * 10
-        s.lives = stage.lives
-        s.life_pieces = stage.life_pieces
-        s.bombs = stage.bombs
-        s.bomb_pieces = stage.bomb_pieces
-        s.graze = stage.graze
-        s.th13_trance = stage.trance
-        s.extends = stage.extends
-        rep_stages.append(s)
-
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
-
-            stage.score = next_stage.score
-            stage.power = next_stage.power
-            stage.piv = next_stage.piv
-            stage.lives = next_stage.lives
-            stage.life_pieces = next_stage.life_pieces
-            stage.bombs = next_stage.bombs
-            stage.bomb_pieces = next_stage.bomb_pieces
-            stage.graze = next_stage.graze
-            stage.th13_trance = next_stage.th13_trance
-            stage.extends = next_stage.extends
+    for current_stage, next_stage in zip(
+        replay.stages, replay.stages[1:] + [None]
+    ):
+        s = ReplayStage(
+            stage=current_stage.stage_num,
+            score=replay.header.score * 10
+        )
+        if next_stage is not None:
+            s.score = next_stage.score * 10
+            s.power = next_stage.power
+            s.piv = (math.trunc(next_stage.piv / 1000)) * 10
+            s.lives = next_stage.lives
+            s.life_pieces = next_stage.life_pieces
+            s.bombs = next_stage.bombs
+            s.bomb_pieces = next_stage.bomb_pieces
+            s.graze = next_stage.graze
+            s.th13_trance = next_stage.trance
+            s.extends = next_stage.extends
         else:
-            stage = rep_stages[i]
-            stage.score = replay.header.score * 10
-            stage.power = None
-            stage.piv = None
-            stage.lives = None
-            stage.life_pieces = None
-            stage.bombs = None
-            stage.bomb_pieces = None
-            stage.graze = None
-            stage.th13_trance = None
-            stage.extends = None
-
+            s.score = replay.header.score * 10
+        rep_stages.append(s)
+        
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and replay.header.difficulty != 4:
         r_type = game_ids.ReplayTypes.STAGE_PRACTICE
@@ -739,42 +647,24 @@ def _Parse14(rep_raw):
             spell_card_id=replay.header.spell_practice_id
         )
 
-    for stage in replay.stages:
-        s = ReplayStage()
-        s.stage = stage.stage_num
-        s.score = stage.score * 10
-        s.power = stage.power
-        s.piv = (math.trunc(stage.piv / 1000)) * 10
-        s.lives = stage.lives
-        s.life_pieces = stage.life_pieces
-        s.bombs = stage.bombs
-        s.bomb_pieces = stage.bomb_pieces
-        s.graze = stage.graze
-        rep_stages.append(s)
-
-    for i in range(len(rep_stages)):
-        if i < len(rep_stages) - 1:
-            stage = rep_stages[i]
-            next_stage = rep_stages[i + 1]
-
-            stage.score = next_stage.score
-            stage.power = next_stage.power
-            stage.piv = next_stage.piv
-            stage.lives = next_stage.lives
-            stage.life_pieces = next_stage.life_pieces
-            stage.bombs = next_stage.bombs
-            stage.bomb_pieces = next_stage.bomb_pieces
-            stage.graze = next_stage.graze
+    for current_stage, next_stage in zip(
+        replay.stages, replay.stages[1:] + [None]
+    ):
+        s = ReplayStage(
+            stage=current_stage.stage_num,
+        )
+        if next_stage is not None:
+            s.score = next_stage.score * 10
+            s.power = next_stage.power
+            s.piv = (math.trunc(next_stage.piv / 1000)) * 10
+            s.lives = next_stage.lives
+            s.life_pieces = next_stage.life_pieces
+            s.bombs = next_stage.bombs
+            s.bomb_pieces = next_stage.bomb_pieces
+            s.graze = next_stage.graze
         else:
-            stage = rep_stages[i]
-            stage.score = replay.header.score * 10
-            stage.power = None
-            stage.piv = None
-            stage.lives = None
-            stage.life_pieces = None
-            stage.bombs = None
-            stage.bomb_pieces = None
-            stage.graze = None
+            s.score = replay.header.score * 10
+        rep_stages.append(s)
 
     r_type = game_ids.ReplayTypes.REGULAR
     if len(rep_stages) == 1 and replay.header.difficulty != 4:


### PR DESCRIPTION
Previously, stage parsing was done in two steps: First create objects containing start-of-stage data and then change them in place to contain end-of-stage data. I reworked this so that it's a 1-stage process.

For th10-th14, I use `zip(stages, stages[1:])` to iterate through pairs of stages. th06-th08 have dummy stages, so I have to first enumerate, then filter dummies, then zip. th09 is even more complicated so I decided not to change it, and added a comment instead.

Tests are unchanged, tests still pass.