### PR TITLE
Add meta tags so that Discord previews links.

### DIFF
--- a/project/thscoreboard/thscoreboard/templates/base.html
+++ b/project/thscoreboard/thscoreboard/templates/base.html
@@ -9,6 +9,10 @@
     <link rel="stylesheet" href="{% static 'fonts/Lato.css' %}">
     <link rel="stylesheet" href="{% static 'fonts/EBGaramond.css' %}">
     {% block favicon %}<link rel="icon" type="image/png" href="{% static 'favicon.png' %}" sizes="48x48">{% endblock %}
+    <meta property="og:title" content="{% block embed_title %}Silent Selene{% endblock %}" />
+    <meta property="og:site_name" content="Silent Selene" />
+    <meta property="og:description" content="{% block embed_description %}Upload and view Touhou replays at Silent Selene, the modern replay hub.{% endblock %}" />
+    <meta property="og:image" content="{% block embed_favicon %}{% static 'favicon.png' %}{% endblock %}" />
 </head>
 
 <body class="theme-light {% block body-class %}{% endblock %}">


### PR DESCRIPTION
This is not really that useful right now, but later we can change the preview based on the page. It would be cool to do stuff like say the game and author for a replay.

It should look something like this:
![image](https://user-images.githubusercontent.com/9295955/219969729-3fc51512-acc3-4acb-a57e-37928fe53cc6.png)

I wanted to set the preview title by default to the actual title of the page, but unfortunately Django is bad and makes that quite difficult, so I gave up.