### PR TITLE
Bugfix: Fix SA Marisa A power display

### DIFF
--- a/project/thscoreboard/replays/game_fields.py
+++ b/project/thscoreboard/replays/game_fields.py
@@ -2,8 +2,9 @@
 
 import copy
 from immutabledict import immutabledict
-from typing import Optional
+from typing import Iterable, Optional
 from . import game_ids
+from replays import models
 
 #   These table fields configure the display of the stage split columns
 #   These may differ from whether the replay file actually has the field or not
@@ -341,11 +342,13 @@ _game_fields_PVP = immutabledict({
 })
 
 
-def GetFormatPower(game_id: str, power: Optional[int]) -> str:
+def GetFormatPower(game_id: str, power: Optional[int], shot_name: Optional[str] = None) -> str:
     if power is None:
         return ""
     if game_id in (game_ids.GameIDs.TH06, game_ids.GameIDs.TH07, game_ids.GameIDs.TH08):
         return str(power)
+    if game_id == game_ids.GameIDs.TH11 and shot_name == "MarisaA":
+        return "%.2f" % (float(power) / 12)
     if game_id in (game_ids.GameIDs.TH10, game_ids.GameIDs.TH11):
         return "%.2f" % (float(power) * 0.05)
     if game_id in (
@@ -491,12 +494,12 @@ def GetFormatStage(game_id: str, stage: Optional[int]) -> str:
     return str(stage)
 
 
-def FormatStages(game_id: str, replay_stages):
+def FormatStages(game_id: str, replay_stages: Iterable[models.ReplayStage], shot_name: str):
     """This function formats the stage values to be displayed in the front end"""
     new_stages = copy.deepcopy(replay_stages)
 
     for stage in new_stages:
-        stage.power = GetFormatPower(game_id, stage.power)
+        stage.power = GetFormatPower(game_id, stage.power, shot_name)
         stage.stage = GetFormatStage(game_id, stage.stage)
         stage.lives = GetFormatLives(game_id, stage.lives, stage.life_pieces, stage.extends)
         stage.bombs = GetFormatBombs(game_id, stage.bombs, stage.bomb_pieces)

--- a/project/thscoreboard/replays/game_fields.py
+++ b/project/thscoreboard/replays/game_fields.py
@@ -342,13 +342,13 @@ _game_fields_PVP = immutabledict({
 })
 
 
-def GetFormatPower(game_id: str, power: Optional[int], shot_name: Optional[str] = None) -> str:
+def GetFormatPower(game_id: str, power: Optional[int], shot: Optional[str] = None) -> str:
     if power is None:
         return ""
     if game_id in (game_ids.GameIDs.TH06, game_ids.GameIDs.TH07, game_ids.GameIDs.TH08):
         return str(power)
-    if game_id == game_ids.GameIDs.TH11 and shot_name == "MarisaA":
-        return "%.2f" % (float(power) / 12)
+    if game_id == game_ids.GameIDs.TH11 and shot == "MarisaA":
+        return "%.2f" % round(float(power) / 12, ndigits=2)
     if game_id in (game_ids.GameIDs.TH10, game_ids.GameIDs.TH11):
         return "%.2f" % (float(power) * 0.05)
     if game_id in (
@@ -494,12 +494,12 @@ def GetFormatStage(game_id: str, stage: Optional[int]) -> str:
     return str(stage)
 
 
-def FormatStages(game_id: str, replay_stages: Iterable[models.ReplayStage], shot_name: str):
+def FormatStages(game_id: str, replay_stages: Iterable[models.ReplayStage], shot: str):
     """This function formats the stage values to be displayed in the front end"""
     new_stages = copy.deepcopy(replay_stages)
 
     for stage in new_stages:
-        stage.power = GetFormatPower(game_id, stage.power, shot_name)
+        stage.power = GetFormatPower(game_id, stage.power, shot)
         stage.stage = GetFormatStage(game_id, stage.stage)
         stage.lives = GetFormatLives(game_id, stage.lives, stage.life_pieces, stage.extends)
         stage.bombs = GetFormatBombs(game_id, stage.bombs, stage.bomb_pieces)

--- a/project/thscoreboard/replays/test_game_fields.py
+++ b/project/thscoreboard/replays/test_game_fields.py
@@ -68,8 +68,13 @@ class FormatPowerTestCase(unittest.TestCase):
         self.assertEqual(format_20_power, "1.00")
         format_49_power = GetFormatPower(GameIDs.TH11, 49, "ReimuA")
         self.assertEqual(format_49_power, "2.45")
+
+        format_0_power_marisa_a = GetFormatPower(GameIDs.TH11, 0, "MarisaA")
+        self.assertEqual(format_0_power_marisa_a, "0.00")
         format_49_power_marisa_a = GetFormatPower(GameIDs.TH11, 49, "MarisaA")
         self.assertEqual(format_49_power_marisa_a, "4.08")
+        format_8_power_marisa_a = GetFormatPower(GameIDs.TH11, 8, "MarisaA")
+        self.assertEqual(format_8_power_marisa_a, "0.67")
 
     def testTh12(self) -> None:
         format_100_power = GetFormatPower(GameIDs.TH12, 100)

--- a/project/thscoreboard/replays/test_game_fields.py
+++ b/project/thscoreboard/replays/test_game_fields.py
@@ -4,7 +4,7 @@ from replays.testing import test_replays
 from replays import replay_parsing
 from replays.game_ids import GameIDs
 from replays.replay_parsing import ReplayInfo
-from replays.game_fields import GetFormatStage
+from replays.game_fields import GetFormatPower, GetFormatStage
 
 
 def ParseTestReplay(filename: str) -> ReplayInfo:
@@ -12,7 +12,6 @@ def ParseTestReplay(filename: str) -> ReplayInfo:
 
 
 class FormatStageTestCase(unittest.TestCase):
-
     def testNoneStage(self) -> None:
         format_stage = GetFormatStage(GameIDs.TH06, None)
         self.assertEqual(format_stage, "")
@@ -34,7 +33,7 @@ class FormatStageTestCase(unittest.TestCase):
         self.assertEqual(format_stage_6B, "6B")
         format_stage_ex = GetFormatStage(GameIDs.TH08, 9)
         self.assertEqual(format_stage_ex, "Extra")
-        
+
     def testTh09(self) -> None:
         format_stage_2 = GetFormatStage(GameIDs.TH09, 2)
         self.assertEqual(format_stage_2, "2")
@@ -50,6 +49,30 @@ class FormatStageTestCase(unittest.TestCase):
         self.assertEqual(format_stage_6, "6")
         format_stage_ex = GetFormatStage(GameIDs.TH06, 7)
         self.assertEqual(format_stage_ex, "Extra")
-        
+
         format_stage_2 = GetFormatStage(GameIDs.TH10, 2)
         self.assertEqual(format_stage_2, "2")
+
+
+class FormatPowerTestCase(unittest.TestCase):
+    def testNonePower(self) -> None:
+        format_power = GetFormatPower(GameIDs.TH06, None)
+        self.assertEqual(format_power, "")
+
+    def testTh07(self) -> None:
+        format_power = GetFormatPower(GameIDs.TH07, 49)
+        self.assertEqual(format_power, "49")
+
+    def testTh11(self) -> None:
+        format_20_power = GetFormatPower(GameIDs.TH11, 20, "ReimuA")
+        self.assertEqual(format_20_power, "1.00")
+        format_49_power = GetFormatPower(GameIDs.TH11, 49, "ReimuA")
+        self.assertEqual(format_49_power, "2.45")
+        format_49_power_marisa_a = GetFormatPower(GameIDs.TH11, 49, "MarisaA")
+        self.assertEqual(format_49_power_marisa_a, "4.08")
+
+    def testTh12(self) -> None:
+        format_100_power = GetFormatPower(GameIDs.TH12, 100)
+        self.assertEqual(format_100_power, "1.00")
+        format_49_power = GetFormatPower(GameIDs.TH12, 49)
+        self.assertEqual(format_49_power, "0.49")

--- a/project/thscoreboard/replays/test_view_replay.py
+++ b/project/thscoreboard/replays/test_view_replay.py
@@ -48,12 +48,6 @@ class TestTableFields(test_case.ReplayTestCase):
 
 class TestGameFields(test_case.ReplayTestCase):
 
-    def testGetPower(self):
-        self.assertEqual(game_fields.GetFormatPower(game_ids.GameIDs.TH06, 100), '100')
-        self.assertEqual(game_fields.GetFormatPower(game_ids.GameIDs.TH07, 100), '100')
-        self.assertEqual(game_fields.GetFormatPower(game_ids.GameIDs.TH10, 100), '5.00')
-        self.assertEqual(game_fields.GetFormatPower(game_ids.GameIDs.TH10, 66), '3.30')
-
     def testGetFormatLives(self):
 
         self.assertEqual(game_fields.GetFormatLives(game_ids.GameIDs.TH11, 5, 2), '5 (2/5)')

--- a/project/thscoreboard/replays/views/view_replay.py
+++ b/project/thscoreboard/replays/views/view_replay.py
@@ -38,7 +38,7 @@ def replay_details(request, game_id: str, replay_id: int):
         # Wrong game, but IDs are unique anyway so we know the right game. Send the user there.
         return redirect(replay_details, game_id=replay_instance.shot.game.game_id, replay_id=replay_id)
 
-    formatStages = game_fields.FormatStages(game_id, replay_stages, replay_instance.shot.GetName())
+    formatStages = game_fields.FormatStages(game_id, replay_stages, replay_instance.shot.shot_id)
 
     edit_form = forms.EditReplayForm(
         initial={

--- a/project/thscoreboard/replays/views/view_replay.py
+++ b/project/thscoreboard/replays/views/view_replay.py
@@ -1,5 +1,6 @@
 """Views related to looking at a saved replay."""
 
+from typing import Iterable, Tuple
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, Http404
 from django.contrib.auth import decorators as auth_decorators
 from django.views.decorators import http as http_decorators
@@ -37,7 +38,7 @@ def replay_details(request, game_id: str, replay_id: int):
         # Wrong game, but IDs are unique anyway so we know the right game. Send the user there.
         return redirect(replay_details, game_id=replay_instance.shot.game.game_id, replay_id=replay_id)
 
-    formatStages = game_fields.FormatStages(game_id, replay_stages)
+    formatStages = game_fields.FormatStages(game_id, replay_stages, replay_instance.shot.GetName())
 
     edit_form = forms.EditReplayForm(
         initial={
@@ -155,7 +156,7 @@ def GetReplayOr404(user, replay_id):
 
 
 @transaction.atomic
-def GetReplayWithStagesOr404(user, replay_id):
+def GetReplayWithStagesOr404(user, replay_id) -> Tuple[models.Replay, Iterable[models.ReplayStage]]:
     try:
         replay_instance = models.Replay.objects.select_related('shot').visible_to(user).get(id=replay_id)
     except models.Replay.DoesNotExist:


### PR DESCRIPTION
Currently, SA Marisa A's power is displayed as power/20, when it should be power/12.

To fix this, I introduced the parameter `shot_name` to `GetFormatPower`. I get the shot name via a call to `replay_instance.shot.GetName()` - I have no idea if this is correct or how to test that.