### PR TITLE
Remove unused function GetGameLifePieces

### DIFF
--- a/project/thscoreboard/replays/game_fields.py
+++ b/project/thscoreboard/replays/game_fields.py
@@ -471,12 +471,6 @@ def GetGameField(gameid: str, replay_type: game_ids.ReplayTypes):
     return None
 
 
-def GetGameLifePieces(gameid: str):
-    if gameid in _life_pieces:
-        return _life_pieces[gameid]
-    return None
-
-
 FORMAT_EXTRA = 'Extra'
 FORMAT_PHANTASM = 'Phantasm'
 


### PR DESCRIPTION
The function `GetGameLifePieces` was added at the same time as GetFormatLives in [this commit](https://github.com/jgdhs27/thscoreboard/commit/ce589f4a25267fed242aa02bdb6fd48b91e0cb90). It seems to be unused and added by mistake.