### PR TITLE
Move ReplayConstantModels to models.py to avoid circular import

### DIFF
--- a/project/thscoreboard/replays/constant_helpers.py
+++ b/project/thscoreboard/replays/constant_helpers.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import dataclasses
-import typing
 from typing import Optional
 
 from django import apps
 
 from replays import replay_parsing
 import hashlib
-
-if typing.TYPE_CHECKING:
-    # Avoid cyclic import.
-    from replays import models
+from replays import models
 
 
 def _Route():
@@ -31,7 +27,7 @@ class ReplayConstantModels:
     route: Optional[models.Route]
 
 
-def GetModelInstancesForReplay(replay_info: replay_parsing.ReplayInfo) -> ReplayConstantModels:
+def GetModelInstancesForReplay(replay_info: replay_parsing.ReplayInfo) -> models.ReplayConstantModels:
     """Get the constant model instances related to this replay."""
     shot = _Shot().objects.select_related('game').get(game=replay_info.game, shot_id=replay_info.shot)
     if replay_info.route:

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -1,6 +1,7 @@
 """Contains all of the models for the replay site."""
 
 
+import dataclasses
 import datetime
 from typing import Optional
 
@@ -9,7 +10,6 @@ from django.contrib import auth
 from django.utils import timezone
 from django.utils.translation import pgettext_lazy
 
-from replays import constant_helpers
 from replays import game_ids
 from replays import limits
 from replays import replay_parsing
@@ -178,6 +178,13 @@ class ReplayQuerySet(models.QuerySet):
         return q
 
 
+@dataclasses.dataclass(frozen=True)
+class ReplayConstantModels:
+    game: Game
+    shot: Shot
+    route: Optional[Route]
+
+
 class Replay(models.Model):
     """Represents a score recorded on the scoreboard."""
 
@@ -332,7 +339,7 @@ class Replay(models.Model):
         self.replay_type = r.replay_type
         self.slowdown = r.slowdown
 
-    def SetForeignKeysFromConstantModels(self, c: constant_helpers.ReplayConstantModels):
+    def SetForeignKeysFromConstantModels(self, c: ReplayConstantModels):
         """Set the shot and route foreign keys on this Replay."""
         self.shot = c.shot
         self.route = c.route


### PR DESCRIPTION
Not a satisfying fix, but it seems to fix the tests