### PR TITLE
Split up replay table

### DIFF
--- a/project/thscoreboard/replays/templates/replays/replay_table.html
+++ b/project/thscoreboard/replays/templates/replays/replay_table.html
@@ -1,5 +1,5 @@
 {% load humanize %}
-<table id="replay-table" class="replay-table">
+<table class="replay-table">
     <thead>
         <tr>
             <th>
@@ -27,9 +27,10 @@
             </th>
         </tr>
     </thead>
-    <tbody>
+    <tbody id="replay-table-body">
     </tbody>
 </table>
+
 
 <!-- This script is a hack to get variables from python into a js file  -->
 <script>

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -1,3 +1,6 @@
+const replayTableBatchSize = 50;
+const replayTableBodyHtml = document.getElementById('replay-table-body');
+
 // Initialize global variables if they were not provided by html
 // Needed for jest environment
 
@@ -15,8 +18,8 @@ try {
   xhr.responseType = 'json';
   xhr.onload = function() {
     if (xhr.status === 200) {
-      populateTable(xhr.response);
       allReplays = xhr.response;
+      constructAndRenderReplayTable(xhr.response);
     } else {
       document.getElementById('replay-table').innerHTML = '<p style="color: red;">Failed to load replays</p>';
     }
@@ -32,7 +35,7 @@ function onClick(elm) {
   
   activeFilters = updateFilters(activeFilters, filterType, value);
   const filteredReplays = filterReplays(activeFilters, allReplays);
-  populateTable(filteredReplays);
+  constructAndRenderReplayTable(filteredReplays);
 }
 
 function updateFilters(filters, filterType, value) {
@@ -62,14 +65,42 @@ function filterReplays(filters, replays) {
   return filteredReplays;
 }
 
-function populateTable(replays) {
-  const replayTableHtml = document.getElementById('replay-table');
-  const tbody = replayTableHtml.getElementsByTagName('tbody')[0];
+function constructAndRenderReplayTable(replays) {
+  clearTableHtml();
   
-  // Clear the existing rows from the table body
-  tbody.innerHTML = '';
+  let startIndex = 0;
+  let endIndex = Math.min(replayTableBatchSize, replays.length);
+  while (startIndex < replays.length) {
+    isFirstBatch = startIndex === 0;
+    constructAndRenderTableBatch(
+      replays, startIndex, endIndex, isFirstBatch
+    );
+    startIndex += replayTableBatchSize;
+    endIndex += replayTableBatchSize;
+    endIndex = Math.min(endIndex, replays.length);
+  }
+}
 
-  for (const replay of replays) {
+function constructAndRenderTableBatch(replays, startIndex, endIndex, isFirstBatch) {
+  if (isFirstBatch) {
+    populateTable(replays, startIndex, endIndex);
+  } else {
+    delayedPopulateTable(replays, startIndex, endIndex);
+  }
+}
+
+function delayedPopulateTable(replays, startIndex, endIndex) {
+  // Delays the execution of the populateTable function to prevent blocking the
+  // main thread and improve performance. This allows other code to run, such
+  // as UI updates, while the table is being populated.
+  setTimeout(() => {
+    populateTable(replays, startIndex, endIndex)
+  }, 1);
+}
+
+function populateTable(replays, startIndex, endIndex) {
+  for (let i = startIndex; i < endIndex; i++) {
+    const replay = replays[i];
     const row = document.createElement('tr');
     for (const [columnName, value] of Object.entries(replay)) {
       const cell = createTableCell(columnName, value)
@@ -77,19 +108,11 @@ function populateTable(replays) {
         row.appendChild(cell);
       }
     }
-    tbody.appendChild(row);
+    replayTableBodyHtml.appendChild(row);
   }
 }
 
-function createLink(url, text) {
-  const link = document.createElement('a'); // 'a' as in the <a> HTML tag
-  link.href = url;
-  const linkText = document.createTextNode(text);
-  link.appendChild(linkText)
-  return link;
-}
-
-function createTableCell(columnName, value) {
+ function createTableCell(columnName, value) {
   const cell = document.createElement('td');
   if ((columnName === "Game" && !showGameColumn) || columnName === "Id") {
     return null;
@@ -103,6 +126,18 @@ function createTableCell(columnName, value) {
     cell.appendChild(text);
   }
   return cell;
+}
+
+function createLink(url, text) {
+  const link = document.createElement('a'); // 'a' as in the <a> HTML tag
+  link.href = url;
+  const linkText = document.createTextNode(text);
+  link.appendChild(linkText)
+  return link;
+}
+
+function clearTableHtml() {
+  replayTableBodyHtml.innerHTML = '';
 }
 
 try {


### PR DESCRIPTION
Currently, the performance of rendering a large table is bad. For Th08, where I have 4656 replays, it takes quite long for a table to render. During this time, the page does not update and the UI is unresponsive.

To mitigate this, a large replay table is split up into many smaller replay tables that are loaded in series. For every 50 rows, a new table is created. This reduces the time for the page to update, and freezes the UI for less long.

| |Before | After | 
|---|---|---|
| Time taken for page to update (pointerup -> first table rendered) | 0.75s | 0.02s |
| Time taken for page to fully render (pointerup -> last table rendered) | 0.75s  | 0.73s |
| Total blocking time | 0.65s  | 0.33s |


Related issue: #309