### PR TITLE
Cache expensive operations in replay to json conversion

### DIFF
--- a/project/thscoreboard/replays/replays_to_json.py
+++ b/project/thscoreboard/replays/replays_to_json.py
@@ -9,14 +9,6 @@ class ReplayToJsonConverter:
         return shot.game
 
     @lru_cache(maxsize=None)
-    def _get_game_short_name(self, game: models.Game) -> str:
-        return game.GetShortName()
-
-    @lru_cache(maxsize=None)
-    def _get_difficulty_name(self, game: models.Game, replay: models.Replay) -> str:
-        return game_ids.GetDifficultyName(game.game_id, replay.difficulty)
-
-    @lru_cache(maxsize=None)
     def _get_shot_name(self, shot: models.Shot) -> str:
         return shot.GetName()
 
@@ -31,8 +23,8 @@ class ReplayToJsonConverter:
             }
             if replay.user
             else replay.imported_username or replay.name,
-            "Game": self._get_game_short_name(game),
-            "Difficulty": self._get_difficulty_name(game, replay),
+            "Game": game.GetShortName(),
+            "Difficulty": game_ids.GetDifficultyName(game.game_id, replay.difficulty),
             "Shot": self._get_shot_name(shot),
             "Score": {
                 "text": f"{int(replay.score):,}",

--- a/project/thscoreboard/replays/replays_to_json.py
+++ b/project/thscoreboard/replays/replays_to_json.py
@@ -1,12 +1,29 @@
 from typing import Iterable
-from replays import models
+from replays import models, game_ids
+from functools import lru_cache
 
 
-def convert_replays_to_serializable_list(
-    replays: Iterable[models.Replay],
-) -> list[dict[str, any]]:
-    replay_dicts = [
-        {
+class ReplayToJsonConverter:
+    @lru_cache(maxsize=None)
+    def _get_game(self, shot: models.Shot) -> models.Game:
+        return shot.game
+
+    @lru_cache(maxsize=None)
+    def _get_game_short_name(self, game: models.Game) -> str:
+        return game.GetShortName()
+
+    @lru_cache(maxsize=None)
+    def _get_difficulty_name(self, game: models.Game, replay: models.Replay) -> str:
+        return game_ids.GetDifficultyName(game.game_id, replay.difficulty)
+
+    @lru_cache(maxsize=None)
+    def _get_shot_name(self, shot: models.Shot) -> str:
+        return shot.GetName()
+
+    def _convert_replay_to_dict(self, replay: models.Replay) -> dict:
+        shot = replay.shot
+        game = self._get_game(shot)
+        return {
             "Id": replay.id,
             "User": {
                 "text": f"{replay.user.username}",
@@ -14,19 +31,22 @@ def convert_replays_to_serializable_list(
             }
             if replay.user
             else replay.imported_username or replay.name,
-            "Game": replay.shot.game.GetShortName(),
-            "Difficulty": replay.GetDifficultyName(),
-            "Shot": replay.shot.GetName(),
+            "Game": self._get_game_short_name(game),
+            "Difficulty": self._get_difficulty_name(game, replay),
+            "Shot": self._get_shot_name(shot),
             "Score": {
                 "text": f"{int(replay.score):,}",
-                "url": f"/replays/{replay.shot.game.game_id}/{replay.id}",
+                "url": f"/replays/{game.game_id}/{replay.id}",
             },
             "Upload Date": replay.created.strftime("%Y-%m-%d"),
             "Replay": {
                 "text": "Download",
-                "url": f"/replays/{replay.shot.game.game_id}/{replay.id}",
+                "url": f"/replays/{game.game_id}/{replay.id}",
             },
         }
-        for replay in replays
-    ]
-    return replay_dicts
+
+    def convert_replays_to_serializable_list(
+        self,
+        replays: Iterable[models.Replay],
+    ) -> list[dict[str, any]]:
+        return [self._convert_replay_to_dict(replay) for replay in replays]

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -1,5 +1,5 @@
 from replays.testing import test_case
-from replays.replays_to_json import convert_replays_to_serializable_list
+from replays.replays_to_json import ReplayToJsonConverter
 from replays.test_replay_parsing import ParseTestReplay
 from replays.create_replay import PublishNewReplay
 from replays import models
@@ -57,7 +57,8 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         replays = [replay_1, replay_2]
 
-        json_data = convert_replays_to_serializable_list(replays)
+        converter = ReplayToJsonConverter()
+        json_data = converter.convert_replays_to_serializable_list(replays)
 
         assert len(json_data) == len(replays)
 

--- a/project/thscoreboard/replays/views/index.py
+++ b/project/thscoreboard/replays/views/index.py
@@ -5,7 +5,7 @@ from django.shortcuts import render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import convert_replays_to_serializable_list
+from replays.replays_to_json import ReplayToJsonConverter
 
 
 @http_decorators.require_safe
@@ -13,8 +13,9 @@ def index_json(request):
     recent_replays = models.Replay.objects.filter(
         category__in=[models.Category.REGULAR, models.Category.TAS]
     ).order_by("-created")[:10]
+    converter = ReplayToJsonConverter()
     return JsonResponse(
-        convert_replays_to_serializable_list(recent_replays), safe=False
+        converter.convert_replays_to_serializable_list(recent_replays), safe=False
     )
 
 

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -6,13 +6,16 @@ from django.shortcuts import get_object_or_404, render
 
 from replays import models
 from replays.models import Game, Shot
-from replays.replays_to_json import convert_replays_to_serializable_list
+from replays.replays_to_json import ReplayToJsonConverter
 
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
+    converter = ReplayToJsonConverter()
     return JsonResponse(
-        convert_replays_to_serializable_list(_get_all_replay_for_game(game_id)),
+        converter.convert_replays_to_serializable_list(
+            _get_all_replay_for_game(game_id)
+        ),
         safe=False,
     )
 

--- a/project/thscoreboard/replays/views/user.py
+++ b/project/thscoreboard/replays/views/user.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import convert_replays_to_serializable_list
+from replays.replays_to_json import ReplayToJsonConverter
 
 
 @http_decorators.require_safe
@@ -16,7 +16,10 @@ def user_page_json(request, username: str):
     user_replays = models.Replay.objects.filter(user=user).order_by(
         "shot__game_id", "shot_id", "created"
     )
-    return JsonResponse(convert_replays_to_serializable_list(user_replays), safe=False)
+    converter = ReplayToJsonConverter()
+    return JsonResponse(
+        converter.convert_replays_to_serializable_list(user_replays), safe=False
+    )
 
 
 @http_decorators.require_safe


### PR DESCRIPTION
In #309 the network request for the json API was reported to be extremely slow. I looked into it, and the reason was that the funciton `convert_replays_to_serializable_list` was slow. This function makes thousands of calls like `game.GetShortName()` which appear to be expensive (presumably, because they need to fetch a user's locale and create a translated string?).

Since many of these calls are the same (for instance, `game.GetShortName()` will return the same value every time for a game page), I cached all expensive calls. I implemented this using `functools.lru_cache`. This brought the time taken to execute the function for 4500 replays down from 1.7 seconds to 0.2 seconds.

| | Before | After |
| --- | --- | ----------- |
| convert_replays_to_serializable_list | 1.7s | 0.2s |
| th08/json network request| 1.8s | 219ms |
| time for table to display after page load (with #312 checked out) | 1.99s | 589ms |

~~Even after these changes, the function `convert_replays_to_serializable_list` remains one of the most expensive parts of loading the page.~~ Edit: Actually, after the changes, `convert_replays_to_serializable_list` is not really a bottleneck. Even if it was instant, the th08/json network request still takes about 200ms. Unsure what the new bottleneck is. 