### PR TITLE
Add comments to replay tables

### DIFF
--- a/project/thscoreboard/replays/limits.py
+++ b/project/thscoreboard/replays/limits.py
@@ -11,3 +11,4 @@ class FileTooBigError(ValidationError):
 
 
 MAX_COMMENT_LENGTH = 50000
+MAX_SHORTENED_COMMENT_LENGTH = 250

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -360,6 +360,13 @@ class Replay(models.Model):
         self.shot = c.shot
         self.route = c.route
 
+    def GetShortenedComment(self) -> str:
+        """Gets a short version of the replay comment, suitable to be displayed
+        in a table row."""
+        if len(self.comment) <= limits.MAX_SHORTENED_COMMENT_LENGTH:
+            return self.comment
+        return self.comment[:limits.MAX_SHORTENED_COMMENT_LENGTH] + "..."
+
 
 class ReplayStage(models.Model):
     """Represents the end-of-stage data for a stage split for a given replay

--- a/project/thscoreboard/replays/replays_to_json.py
+++ b/project/thscoreboard/replays/replays_to_json.py
@@ -22,6 +22,7 @@ def convert_replays_to_serializable_list(
                 "url": f"/replays/{replay.shot.game.game_id}/{replay.id}",
             },
             "Upload Date": replay.created.strftime("%Y-%m-%d"),
+            "Comment": replay.GetShortenedComment(),
             "Replay": {
                 "text": "Download",
                 "url": f"/replays/{replay.shot.game.game_id}/{replay.id}",

--- a/project/thscoreboard/replays/templates/replays/replay_table.html
+++ b/project/thscoreboard/replays/templates/replays/replay_table.html
@@ -23,6 +23,9 @@
                 Upload Date
             </th>
             <th>
+                Comment
+            </th>
+            <th>
                 Replay
             </th>
         </tr>

--- a/project/thscoreboard/replays/test_models.py
+++ b/project/thscoreboard/replays/test_models.py
@@ -1,6 +1,7 @@
 import datetime
 
 from replays import game_ids
+from replays import limits
 from replays import models
 from replays import constant_helpers
 from replays import create_replay
@@ -91,6 +92,22 @@ class ReplayTest(test_case.ReplayTestCase):
         self.assertEqual(to_be_modified.shot.game.game_id, "th08")
         self.assertEqual(to_be_modified.shot.shot_id, "Marisa & Alice")
         self.assertIsNone(to_be_modified.route)
+
+    def testGetShortenedComment_ShortComment(self) -> None:
+        short_comment = "a" * limits.MAX_SHORTENED_COMMENT_LENGTH
+        replay = test_replays.CreateAsPublishedReplay(
+            filename="th6_extra", user=self.author, comment=short_comment
+        )
+        expected_shortened_comment = short_comment
+        self.assertEqual(replay.GetShortenedComment(), expected_shortened_comment)
+
+    def testGetShortenedComment_LongComment(self) -> None:
+        long_comment = "a" * (limits.MAX_SHORTENED_COMMENT_LENGTH + 1)
+        replay = test_replays.CreateAsPublishedReplay(
+            filename="th6_extra", user=self.author, comment=long_comment
+        )
+        expected_shortened_comment = "a" * limits.MAX_SHORTENED_COMMENT_LENGTH + "..."
+        self.assertEqual(replay.GetShortenedComment(), expected_shortened_comment)
 
 
 class TemporaryReplayFileTest(test_case.ReplayTestCase):

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -1,3 +1,4 @@
+import datetime
 from replays.testing import test_case
 from replays.replays_to_json import convert_replays_to_serializable_list
 from replays.test_replay_parsing import ParseTestReplay
@@ -31,6 +32,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
             no_bomb=False,
             miss_count=None,
             replay_info=replay_info_1,
+            created_timestamp=datetime.datetime(2000, 1, 1),
         )
 
         replay_info_2 = ParseTestReplay("th16_extra")
@@ -87,7 +89,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
         assert json_data[0]["Difficulty"] == "Easy"
         assert json_data[0]["Shot"] == "Reimu A"
         assert json_data[0]["Score"]["text"] == "1,000,000"
-        assert json_data[0]["Upload Date"] == "2023-04-06"
+        assert json_data[0]["Upload Date"] == "2000-01-01"
         assert json_data[0]["Comment"] == "鼻毛"
         assert json_data[0]["Replay"]["text"] == "Download"
 

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -23,7 +23,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
             difficulty=0,
             score=1_000_000,
             category=0,
-            comment="Comment",
+            comment="鼻毛",
             video_link="",
             temp_replay_instance=temp_replay_1,
             is_good=True,
@@ -61,9 +61,6 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         assert len(json_data) == len(replays)
 
-        assert json_data[0]["User"]["text"] == self.user.username
-        assert json_data[1]["User"] == "あ"
-
         for replay, json_replay_data in zip(replays, json_data):
             assert json_replay_data
             assert set(json_replay_data.keys()) == {
@@ -74,12 +71,24 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
                 "Shot",
                 "Score",
                 "Upload Date",
+                "Comment",
                 "Replay",
             }
-            assert json_replay_data["Game"] == replay.shot.game.GetShortName()
 
             assert type(json_replay_data["Score"]) == dict
             assert set(json_replay_data["Score"].keys()) == {"text", "url"}
 
             assert type(json_replay_data["Replay"]) == dict
             assert set(json_replay_data["Replay"].keys()) == {"text", "url"}
+
+        assert json_data[0]["User"]["text"] == self.user.username
+        assert json_data[0]["User"]["url"] == f"/replays/user/{self.user.username}"
+        assert json_data[0]["Game"] == "th06"
+        assert json_data[0]["Difficulty"] == "Easy"
+        assert json_data[0]["Shot"] == "Reimu A"
+        assert json_data[0]["Score"]["text"] == "1,000,000"
+        assert json_data[0]["Upload Date"] == "2023-04-06"
+        assert json_data[0]["Comment"] == "鼻毛"
+        assert json_data[0]["Replay"]["text"] == "Download"
+
+        assert json_data[1]["User"] == "あ"

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -102,6 +102,9 @@ function createTableCell(columnName, value) {
     const text = document.createTextNode(value);
     cell.appendChild(text);
   }
+  if (columnName === "Shot") {
+    cell.style.whiteSpace = "nowrap";
+  }
   return cell;
 }
 

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -103,7 +103,7 @@ function createTableCell(columnName, value) {
     cell.appendChild(text);
   }
   if (columnName === "Shot") {
-    cell.style.whiteSpace = "nowrap";
+    cell.className = "nowrap";
   }
   return cell;
 }

--- a/project/thscoreboard/shared_content/static/style.sass
+++ b/project/thscoreboard/shared_content/static/style.sass
@@ -188,6 +188,9 @@ th, td
         td
             text-align: right
 
+    .nowrap
+        white-space: nowrap
+
 .replay-header
     h3
         font-weight: bold

--- a/project/thscoreboard/shared_content/static/style.sass
+++ b/project/thscoreboard/shared_content/static/style.sass
@@ -177,6 +177,7 @@ th, td
 
 .replay-table
     thead
+        white-space: nowrap
         background-color: var(--table-header-color)
     tbody
         tr:nth-child(odd)


### PR DESCRIPTION
Adds comments to replay tables. If the comment contains more than 250 characters, it is cut off and only the first 250 characters are shown. Also adds some small formatting changes to the table, to prevent certain entries (shot name, date) from wrapping and taking up muiltiple lines.

![image](https://user-images.githubusercontent.com/44336657/230461735-b881afa5-9a79-47de-aeff-a1aa34c2297f.png)
