### PR TITLE
Derive replay type from game

### DIFF
--- a/project/thscoreboard/replays/forms.py
+++ b/project/thscoreboard/replays/forms.py
@@ -61,6 +61,17 @@ def _create_comment_field():
     )
 
 
+def _get_replay_type_choices(game: models.Game) -> list[Tuple[str, str]]:
+    replay_types = [
+        ("1", _("Regular")),
+        ("2", _("Stage Practice")),
+    ]
+    games_with_pvp = [game_ids.GameIDs.TH03, game_ids.GameIDs.TH09]
+    if game.game_id in games_with_pvp:
+        replay_types.append(("4", _("PVP")))
+    return replay_types
+
+
 class ShotField(forms.ModelChoiceField):
     """A field defining shot type. You must call set_queryset before using."""
 
@@ -160,6 +171,7 @@ class PublishReplayWithoutFileForm(forms.Form):
             del self.fields["route"]
 
         self.fields["difficulty"].choices = _GetDifficultyChoices(game)
+        self.fields["replay_type"].choices = _get_replay_type_choices(game)
 
         if not game_ids.HasBombs(game.game_id):
             del self.fields["uses_bombs"]

--- a/project/thscoreboard/replays/forms.py
+++ b/project/thscoreboard/replays/forms.py
@@ -8,6 +8,7 @@ from django.core import exceptions
 from django.utils.translation import gettext as _
 
 from replays import game_ids
+from replays import game_fields
 from replays import models
 from replays import limits
 
@@ -66,8 +67,7 @@ def _get_replay_type_choices(game: models.Game) -> list[Tuple[str, str]]:
         ("1", _("Regular")),
         ("2", _("Stage Practice")),
     ]
-    games_with_pvp = [game_ids.GameIDs.TH03, game_ids.GameIDs.TH09]
-    if game.game_id in games_with_pvp:
+    if game_fields.game_has_pvp(game.game_id):
         replay_types.append(("4", _("PVP")))
     return replay_types
 

--- a/project/thscoreboard/replays/game_fields.py
+++ b/project/thscoreboard/replays/game_fields.py
@@ -589,3 +589,10 @@ def FormatStages(game_id: str, replay_stages: Iterable[models.ReplayStage], shot
             stage.extends = ""
 
     return new_stages
+
+
+_games_with_pvp = ["th03", "th09"]
+
+
+def game_has_pvp(game_id: str) -> bool:
+    return game_id in _games_with_pvp

--- a/project/thscoreboard/replays/test_forms.py
+++ b/project/thscoreboard/replays/test_forms.py
@@ -1,5 +1,6 @@
 import unittest
 
+from replays.testing.test_case import ReplayTestCase
 from replays import forms
 from replays import game_ids
 from replays import models
@@ -29,3 +30,27 @@ class PublishReplayFormTest(unittest.TestCase):
             game_ids.GameIDs.TH13, models.ReplayType.SPELL_PRACTICE
         )
         self.assertNotIn("misses", f.fields)
+
+
+class PublishReplayWithoutFileFormTest(ReplayTestCase):
+    def testPvpReplayType_Included(self):
+        th03 = models.Game.objects.get(game_id="th03")
+        f = forms.PublishReplayWithoutFileForm(game=th03)
+        replay_type_choices = [entry[1] for entry in f.fields["replay_type"].choices]
+        self.assertIn("PVP", replay_type_choices)
+
+    def testPvpReplayType_NotIncluded(self):
+        game_ids_without_pvp = [
+            game_ids.GameIDs.TH01,
+            game_ids.GameIDs.TH02,
+            game_ids.GameIDs.TH04,
+            game_ids.GameIDs.TH05,
+        ]
+        for game_id in game_ids_without_pvp:
+            with self.subTest():
+                game = models.Game.objects.get(game_id=game_id)
+                f = forms.PublishReplayWithoutFileForm(game=game)
+                replay_type_choices = [
+                    entry[1] for entry in f.fields["replay_type"].choices
+                ]
+                self.assertNotIn("PVP", replay_type_choices)

--- a/project/thscoreboard/replays/test_game_fields.py
+++ b/project/thscoreboard/replays/test_game_fields.py
@@ -9,6 +9,7 @@ from replays.game_fields import (
     GetFormatLives,
     GetFormatPower,
     GetFormatStage,
+    game_has_pvp,
 )
 
 
@@ -131,3 +132,15 @@ class FormatBombsTestCase(unittest.TestCase):
 
         format_bombs = GetFormatBombs(GameIDs.TH12, bombs=4, bomb_pieces=2)
         self.assertEqual(format_bombs, "4 (2/3)")
+
+
+class GameHasPvpTestCase(unittest.TestCase):
+    def testTh03(self) -> None:
+        self.assertTrue(game_has_pvp(GameIDs.TH03))
+
+    def testTh09(self) -> None:
+        self.assertTrue(game_has_pvp(GameIDs.TH09))
+
+    def testNoPvp(self) -> None:
+        for game_id in [GameIDs.TH01, GameIDs.TH06, GameIDs.TH18]:
+            self.assertFalse(game_has_pvp(game_id))


### PR DESCRIPTION
Derive the replay type choices in the "Publish Replay Without File Form" from the game.

Currently, replays uploaded without file will always show all replay types, including PVP. This is a bug, as TH01, TH02, TH04 and TH05 do not support PVP.

Fixes #316