### PR TITLE
Fix replay username parsing

### DIFF
--- a/project/thscoreboard/replays/kaitai_parsers/th06.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th06.py
@@ -39,7 +39,7 @@ class Th06(KaitaiStruct):
         def _read(self):
             self.unknown_2 = self._io.read_u1()
             self.date = (KaitaiStream.bytes_terminate(self._io.read_bytes(9), 0, False)).decode(u"ASCII")
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(9), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(9), 0, False)).decode(u"SJIS")
             self.unknown_3 = self._io.read_u2le()
             self.score = self._io.read_u4le()
             self.unknown_4 = self._io.read_u4le()

--- a/project/thscoreboard/replays/kaitai_parsers/th07.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th07.py
@@ -70,7 +70,7 @@ class Th07(KaitaiStruct):
             self.shot = self._io.read_u1()
             self.difficulty = self._io.read_u1()
             self.date = (KaitaiStream.bytes_terminate(self._io.read_bytes(6), 0, False)).decode(u"ASCII")
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(9), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(9), 0, False)).decode(u"SJIS")
             self.unknown_2 = self._io.read_bytes(5)
             self.score = self._io.read_u4le()
             self.unknown_3 = []

--- a/project/thscoreboard/replays/kaitai_parsers/th08.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th08.py
@@ -71,7 +71,7 @@ class Th08(KaitaiStruct):
             self.shot = self._io.read_u1()
             self.difficulty = self._io.read_u1()
             self.date = (KaitaiStream.bytes_terminate(self._io.read_bytes(6), 0, False)).decode(u"ASCII")
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(10), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(10), 0, False)).decode(u"SJIS")
             self.spell_card_id = self._io.read_u2le()
             self.spell_card_name = (KaitaiStream.bytes_terminate(self._io.read_bytes(50), 0, False)).decode(u"SJIS")
             self.score = self._io.read_u4le()

--- a/project/thscoreboard/replays/kaitai_parsers/th09.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th09.py
@@ -68,7 +68,7 @@ class Th09(KaitaiStruct):
         def _read(self):
             self.unknown_1 = self._io.read_u4le()
             self.date = (KaitaiStream.bytes_terminate(self._io.read_bytes(10), 0, False)).decode(u"ASCII")
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(9), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(9), 0, False)).decode(u"SJIS")
             self.difficulty = self._io.read_u1()
 
 

--- a/project/thscoreboard/replays/kaitai_parsers/th10.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th10.py
@@ -29,7 +29,7 @@ class Th10(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (self._io.read_bytes(12)).decode(u"ASCII")
+            self.name = (self._io.read_bytes(12)).decode(u"SJIS")
             self.timestamp = self._io.read_u4le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(52)

--- a/project/thscoreboard/replays/kaitai_parsers/th11.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th11.py
@@ -29,7 +29,7 @@ class Th11(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(60)

--- a/project/thscoreboard/replays/kaitai_parsers/th12.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th12.py
@@ -29,7 +29,7 @@ class Th12(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(60)

--- a/project/thscoreboard/replays/kaitai_parsers/th13.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th13.py
@@ -29,7 +29,7 @@ class Th13(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown = self._io.read_bytes(60)

--- a/project/thscoreboard/replays/kaitai_parsers/th14.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th14.py
@@ -29,7 +29,7 @@ class Th14(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(92)

--- a/project/thscoreboard/replays/kaitai_parsers/th15.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th15.py
@@ -29,7 +29,7 @@ class Th15(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(108)

--- a/project/thscoreboard/replays/kaitai_parsers/th16.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th16.py
@@ -29,7 +29,7 @@ class Th16(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(12), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(100)

--- a/project/thscoreboard/replays/kaitai_parsers/th17.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th17.py
@@ -29,7 +29,7 @@ class Th17(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(16), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(16), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(100)

--- a/project/thscoreboard/replays/kaitai_parsers/th18.py
+++ b/project/thscoreboard/replays/kaitai_parsers/th18.py
@@ -29,7 +29,7 @@ class Th18(KaitaiStruct):
             self._read()
 
         def _read(self):
-            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(16), 0, False)).decode(u"ASCII")
+            self.name = (KaitaiStream.bytes_terminate(self._io.read_bytes(16), 0, False)).decode(u"SJIS")
             self.timestamp = self._io.read_u8le()
             self.score = self._io.read_u4le()
             self.unknown_1 = self._io.read_bytes(136)

--- a/ref/threp-ksy/th06.ksy
+++ b/ref/threp-ksy/th06.ksy
@@ -30,7 +30,7 @@ types:
       - id: name
         type: str
         size: 9
-        encoding: ASCII
+        encoding: SJIS
         terminator: 0x0
       - id: unknown_3
         type: u2

--- a/ref/threp-ksy/th07.ksy
+++ b/ref/threp-ksy/th07.ksy
@@ -62,7 +62,7 @@ types:
         terminator: 0x0
       - id: name
         type: str
-        encoding: ASCII
+        encoding: SJIS
         terminator: 0x0
         size: 9
       - id: unknown_2

--- a/ref/threp-ksy/th08.ksy
+++ b/ref/threp-ksy/th08.ksy
@@ -63,7 +63,7 @@ types:
         terminator: 0x0
       - id: name
         type: str
-        encoding: ASCII
+        encoding: SJIS
         terminator: 0x0
         size: 10
       - id: spell_card_id

--- a/ref/threp-ksy/th09.ksy
+++ b/ref/threp-ksy/th09.ksy
@@ -59,7 +59,7 @@ types:
       - id: name
         type: str
         size: 9
-        encoding: ASCII
+        encoding: SJIS
         terminator: 0x0
       - id: difficulty
         type: u1

--- a/ref/threp-ksy/th10.ksy
+++ b/ref/threp-ksy/th10.ksy
@@ -15,7 +15,7 @@ types:
       - id: name
         type: str
         size: 12
-        encoding: ASCII
+        encoding: SJIS
       - id: timestamp
         type: u4
       - id: score

--- a/ref/threp-ksy/th11.ksy
+++ b/ref/threp-ksy/th11.ksy
@@ -16,7 +16,7 @@ types:
         type: str
         size: 12
         terminator: 0x0
-        encoding: ASCII
+        encoding: SJIS
       - id: timestamp
         type: u8
       - id: score

--- a/ref/threp-ksy/th12.ksy
+++ b/ref/threp-ksy/th12.ksy
@@ -16,7 +16,7 @@ types:
         type: str
         size: 12
         terminator: 0x0
-        encoding: ASCII
+        encoding: SJIS
       - id: timestamp
         type: u8
       - id: score

--- a/ref/threp-ksy/th13.ksy
+++ b/ref/threp-ksy/th13.ksy
@@ -16,7 +16,7 @@ types:
       type: str
       size: 12
       terminator: 0
-      encoding: ASCII
+      encoding: SJIS
     - id: timestamp
       type: u8
     - id: score

--- a/ref/threp-ksy/th14.ksy
+++ b/ref/threp-ksy/th14.ksy
@@ -16,7 +16,7 @@ types:
       type: str
       size: 12
       terminator: 0
-      encoding: ASCII
+      encoding: SJIS
     - id: timestamp
       type: u8
     - id: score

--- a/ref/threp-ksy/th15.ksy
+++ b/ref/threp-ksy/th15.ksy
@@ -16,7 +16,7 @@ types:
       type: str
       size: 12
       terminator: 0
-      encoding: ASCII
+      encoding: SJIS
     - id: timestamp
       type: u8
     - id: score

--- a/ref/threp-ksy/th16.ksy
+++ b/ref/threp-ksy/th16.ksy
@@ -16,7 +16,7 @@ types:
       type: str
       size: 12
       terminator: 0
-      encoding: ASCII
+      encoding: SJIS
     - id: timestamp
       type: u8
     - id: score

--- a/ref/threp-ksy/th17.ksy
+++ b/ref/threp-ksy/th17.ksy
@@ -16,7 +16,7 @@ types:
       type: str
       size: 16
       terminator: 0
-      encoding: ASCII
+      encoding: SJIS
     - id: timestamp
       type: u8
     - id: score

--- a/ref/threp-ksy/th18.ksy
+++ b/ref/threp-ksy/th18.ksy
@@ -16,7 +16,7 @@ types:
       type: str
       size: 16
       terminator: 0
-      encoding: ASCII
+      encoding: SJIS
     - id: timestamp
       type: u8
     - id: score


### PR DESCRIPTION
Usernames are encoded using SJIS encoding. However, the parsers used ASCII encoding. This led to errors being thrown on replays that had these characters in their username.

Fixes #322 