### PR TITLE
Support th16 season as a replay table filter

### DIFF
--- a/project/thscoreboard/replays/game_ids.py
+++ b/project/thscoreboard/replays/game_ids.py
@@ -477,6 +477,36 @@ def GetShotName(game_id: str, shot_id: str) -> str:
     return "Bug shot"
 
 
+def GetCharacterName(game_id: str, shot_id: str) -> str:
+    if game_id == GameIDs.TH16:
+        if shot_id.startswith("Reimu"):
+            return pgettext("th16", "Reimu")
+        elif shot_id.startswith("Cirno"):
+            return pgettext("th16", "Cirno")
+        elif shot_id.startswith("Aya"):
+            return pgettext("th16", "Aya")
+        elif shot_id.startswith("Marisa"):
+            return pgettext("th16", "Marisa")
+
+    return "Character name not implemented"
+
+
+def GetSubshotName(game_id: str, shot_id: str) -> Optional[str]:
+    if game_id == GameIDs.TH16:
+        if shot_id.endswith("Spring"):
+            return pgettext("th16", "Spring")
+        elif shot_id.endswith("Summer"):
+            return pgettext("th16", "Summer")
+        elif shot_id.endswith("Autumn"):
+            return pgettext("th16", "Autumn")
+        elif shot_id.endswith("Winter"):
+            return pgettext("th16", "Winter")
+        else:
+            return None
+
+    return "Subshot not implemented"
+
+
 def GetRouteName(game_id: str, route_id: str):
     if game_id == GameIDs.TH01:
         if route_id == "Jigoku":

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -87,6 +87,14 @@ class Shot(models.Model):
         """Get a pretty name for this shot type. Note: Populates game."""
         return game_ids.GetShotName(self.game.game_id, self.shot_id)
 
+    def GetCharacterame(self) -> str:
+        """Get a pretty name for this Character. Note: Populates game."""
+        return game_ids.GetCharacterName(self.game.game_id, self.shot_id)
+
+    def GetSubshotName(self) -> str:
+        """Get a pretty name for this subshot. Note: Populates game."""
+        return game_ids.GetSubshotName(self.game.game_id, self.shot_id)
+
 
 class Category(models.IntegerChoices):
     """The category under which a replay is uploaded."""
@@ -365,13 +373,13 @@ class Replay(models.Model):
         in a table row."""
         if len(self.comment) <= limits.MAX_SHORTENED_COMMENT_LENGTH:
             return self.comment
-        return self.comment[:limits.MAX_SHORTENED_COMMENT_LENGTH] + "..."
+        return self.comment[: limits.MAX_SHORTENED_COMMENT_LENGTH] + "..."
 
 
 class ReplayStage(models.Model):
-    """ Represents the end-of-stage data for a stage split for a given replay
-        The data may not directly correspond to how it is stored in-game, since some games store it differently
-        Many games only store the data from the start of a replay, so many of the fields for the final stage will be null
+    """Represents the end-of-stage data for a stage split for a given replay
+    The data may not directly correspond to how it is stored in-game, since some games store it differently
+    Many games only store the data from the start of a replay, so many of the fields for the final stage will be null
     """
 
     class Meta:

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -87,7 +87,7 @@ class Shot(models.Model):
         """Get a pretty name for this shot type. Note: Populates game."""
         return game_ids.GetShotName(self.game.game_id, self.shot_id)
 
-    def GetCharacterame(self) -> str:
+    def GetCharacterName(self) -> str:
         """Get a pretty name for this Character. Note: Populates game."""
         return game_ids.GetCharacterName(self.game.game_id, self.shot_id)
 

--- a/project/thscoreboard/replays/replays_to_json.py
+++ b/project/thscoreboard/replays/replays_to_json.py
@@ -45,7 +45,7 @@ class ReplayToJsonConverter:
 
     def _get_th16_additional_fields(self, shot: models.Shot) -> dict:
         return {
-            "Character": shot.GetCharacterame(),
+            "Character": shot.GetCharacterName(),
             "Season": shot.GetSubshotName(),
         }
 

--- a/project/thscoreboard/replays/replays_to_json.py
+++ b/project/thscoreboard/replays/replays_to_json.py
@@ -15,7 +15,7 @@ class ReplayToJsonConverter:
     def _convert_replay_to_dict(self, replay: models.Replay) -> dict:
         shot = replay.shot
         game = self._get_game(shot)
-        return {
+        json_dict = {
             "Id": replay.id,
             "User": {
                 "text": f"{replay.user.username}",
@@ -36,6 +36,17 @@ class ReplayToJsonConverter:
                 "text": "Download",
                 "url": f"/replays/{game.game_id}/{replay.id}",
             },
+        }
+
+        if game.game_id == game_ids.GameIDs.TH16:
+            json_dict |= self._get_th16_additional_fields(shot)
+
+        return json_dict
+
+    def _get_th16_additional_fields(self, shot: models.Shot) -> dict:
+        return {
+            "Character": shot.GetCharacterame(),
+            "Season": shot.GetSubshotName(),
         }
 
     def convert_replays_to_serializable_list(

--- a/project/thscoreboard/replays/templates/replays/game_scoreboard.html
+++ b/project/thscoreboard/replays/templates/replays/game_scoreboard.html
@@ -3,26 +3,18 @@
 {% block content %}
     <h2><a href="/replays/{{game.game_id}}">{{ game.GetName }}</a></h2>
 
-    <div class="checkbox-list">
-        {% for difficulty_name in difficulties %}
-            <label><input
-                type="checkbox"
-                filterType="Difficulty"
-                value="{{difficulty_name}}"
-                onclick="onClick(this)"
-            >{{ difficulty_name }}</label>
-        {% endfor %}
-	</div>
-	<div class="checkbox-list">
-        {% for shot in shots %}
-        <label><input
-            type="checkbox"
-            filterType="Shot"
-            value="{{shot}}"
-            onclick="onClick(this)"
-        >{{ shot }}</label>
-        {% endfor %}
-	</div>
+    {% for filter_name, filter_values in filters.items %}
+        <div class="checkbox-list">
+            {% for filter_value in filter_values %}
+                <label><input
+                    type="checkbox"
+                    filterType="{{filter_name}}"
+                    value="{{filter_value}}"
+                    onclick="onClick(this)"
+                >{{ filter_value }}</label>
+            {% endfor %}
+        </div>
+    {% endfor %}
 
     <br />
 

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -66,18 +66,6 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         for replay, json_replay_data in zip(replays, json_data):
             assert json_replay_data
-            assert set(json_replay_data.keys()) == {
-                "Id",
-                "User",
-                "Game",
-                "Difficulty",
-                "Shot",
-                "Score",
-                "Upload Date",
-                "Comment",
-                "Replay",
-            }
-
             assert type(json_replay_data["Score"]) == dict
             assert set(json_replay_data["Score"].keys()) == {"text", "url"}
 
@@ -93,5 +81,11 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
         assert json_data[0]["Upload Date"] == "2000-01-01"
         assert json_data[0]["Comment"] == "鼻毛"
         assert json_data[0]["Replay"]["text"] == "Download"
+        assert "Character" not in json_data[0]["Replay"]["text"]
+        assert "Season" not in json_data[0]["Replay"]["text"]
 
         assert json_data[1]["User"] == "あ"
+        print(json_data[1]["Character"])
+        print(json_data[1]["Season"])
+        assert json_data[1]["Character"] == "Marisa"
+        assert json_data[1]["Season"] == None

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -32,7 +32,9 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
             no_bomb=False,
             miss_count=None,
             replay_info=replay_info_1,
-            created_timestamp=datetime.datetime(2000, 1, 1),
+            created_timestamp=datetime.datetime(
+                2000, 1, 1, tzinfo=datetime.timezone.utc
+            ),
         )
 
         replay_info_2 = ParseTestReplay("th16_extra")
@@ -85,7 +87,5 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
         assert "Season" not in json_data[0]["Replay"]["text"]
 
         assert json_data[1]["User"] == "あ"
-        print(json_data[1]["Character"])
-        print(json_data[1]["Season"])
         assert json_data[1]["Character"] == "Marisa"
         assert json_data[1]["Season"] == None

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -88,4 +88,4 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         assert json_data[1]["User"] == "あ"
         assert json_data[1]["Character"] == "Marisa"
-        assert json_data[1]["Season"] == None
+        assert json_data[1]["Season"] is None

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -48,7 +48,7 @@ def _get_filter_options_default(game: Game) -> dict[str, list[str]]:
 
 def _get_filter_options_th16(game: Game) -> dict[str, list[str]]:
     all_characters = list(
-        set(shot.GetCharacterame() for shot in Shot.objects.filter(game=game.game_id))
+        set(shot.GetCharacterName() for shot in Shot.objects.filter(game=game.game_id))
     )
     all_seasons = list(
         set(shot.GetSubshotName() for shot in Shot.objects.filter(game=game.game_id))

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -1,5 +1,8 @@
 const replayTableBatchSize = 50;
 const replayTableBodyHtml = document.getElementById('replay-table-body');
+const displayedColumns = [
+  "User", "Game", "Difficulty", "Shot", "Score", "Upload Date", "Comment", "Replay"
+];
 
 // Initialize global variables if they were not provided by html
 // Needed for jest environment
@@ -114,7 +117,10 @@ function populateTable(replays, startIndex, endIndex) {
 
  function createTableCell(columnName, value) {
   const cell = document.createElement('td');
-  if ((columnName === "Game" && !showGameColumn) || columnName === "Id") {
+  if (!displayedColumns.includes(columnName)) {
+    return null;
+  }
+  if (columnName === "Game" && !showGameColumn) {
     return null;
   }
 


### PR DESCRIPTION
Allow the replay table to filter th16 replays by character and by season independently.

![image](https://user-images.githubusercontent.com/44336657/231588029-40e6117c-bb30-4d6c-841c-2dd4e3d1dd1e.png)

After this is approved we can try doing something similar for TH17 subshot, and maybe even TH08 route.

Fixes #295