### PR TITLE
Split pc-98 and windows in side bar

### DIFF
--- a/project/thscoreboard/replays/templatetags/get_games.py
+++ b/project/thscoreboard/replays/templatetags/get_games.py
@@ -1,13 +1,28 @@
 """Template tags used to get access to games."""
 
+from typing import Iterable
 from django import template
+from replays import game_ids
 
 from replays import models
 
 register = template.Library()
 
 
+PC98_GAME_IDS = {
+    game_ids.GameIDs.TH01,
+    game_ids.GameIDs.TH02,
+    game_ids.GameIDs.TH03,
+    game_ids.GameIDs.TH04,
+    game_ids.GameIDs.TH05,
+}
+
+
 @register.simple_tag
-def get_all_games():
-    """Returns a list of all Touhou games, in a reasonable order."""
-    return models.Game.objects.all()
+def get_all_games_by_category() -> dict[str, list[models.Game]]:
+    """Returns a list of all Touhou games by category (pc-98, windows, etc.), in a
+    reasonable order."""
+    all_games: Iterable[models.Game] = models.Game.objects.all()
+    pc98_games = [game for game in all_games if game.game_id in PC98_GAME_IDS]
+    windows_games = [game for game in all_games if game.game_id not in PC98_GAME_IDS]
+    return {"PC-98": pc98_games, "Windows": windows_games}

--- a/project/thscoreboard/thscoreboard/templates/base.html
+++ b/project/thscoreboard/thscoreboard/templates/base.html
@@ -3,7 +3,7 @@
 {% load sass_tags %}
 {% load i18n %}
 {% load get_games %}
-{% get_all_games as all_games %}
+{% get_all_games_by_category as all_games_by_category %}
 <html lang="en">
 <head>
     <title>{% block title %}Silent Selene{% endblock %}</title>
@@ -45,11 +45,12 @@
         </div>
         <div class="content-and-sidebar">
             <nav class="sidebar">
+                {% for game_category, games in all_games_by_category.items %}
                 <h1 class="highlight">
-                    Games
+                    {{game_category}}
                 </h1>
                 <ul class="game-list">
-                    {% for game in all_games %}
+                    {% for game in games %}
                     <li>
                         <div class="sidebar-game-icon">
                             <img src="{{game.GetIconPath}}"/>
@@ -60,6 +61,7 @@
                     </li>
                     {% endfor %}
                 </ul>
+                {% endfor %}
                 <h1 class="highlight">
                     About the site
                 </h1>


### PR DESCRIPTION
Currently, all 19 main line touhou games are shown as a list on the side-bar. It takes some effort to find the right game. Therefore, this PR introduces a split between Windows and PC-98. This can be extended for side games in the future.
![image](https://user-images.githubusercontent.com/44336657/233443263-6f684347-086a-414b-94ff-c59407c4df77.png)
