### PR TITLE
Add medal emojis to top 3 scores

### DIFF
--- a/project/thscoreboard/replays/replays_to_json.py
+++ b/project/thscoreboard/replays/replays_to_json.py
@@ -1,6 +1,4 @@
 from typing import Iterable
-from django.db.models import Window, F, Manager
-from django.db.models.functions import RowNumber
 from functools import lru_cache
 
 from replays import models, game_ids
@@ -72,18 +70,6 @@ class ReplayToJsonConverter:
         ranked_replays: Iterable[models.Replay],
     ) -> list[dict[str, any]]:
         return [self._convert_replay_to_dict(replay) for replay in ranked_replays]
-
-
-def add_rank_annotation_to_replays(
-    replays: Manager[models.Replay],
-) -> Manager[models.Replay]:
-    return replays.annotate(
-        rank=Window(
-            expression=RowNumber(),
-            order_by=F("score").desc(),
-            partition_by=[F("shot_id"), F("difficulty"), F("shot__game_id")],
-        )
-    )
 
 
 def _get_medal_emoji(rank: int) -> str:

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -1,12 +1,8 @@
 import datetime
 from unittest.mock import patch
 
-
 from replays.testing import test_case
-from replays.replays_to_json import (
-    ReplayToJsonConverter,
-    add_rank_annotation_to_replays,
-)
+from replays.replays_to_json import ReplayToJsonConverter
 from replays.test_replay_parsing import ParseTestReplay
 from replays.create_replay import PublishNewReplay
 from replays import models
@@ -30,7 +26,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
             user=self.user,
             difficulty=0,
             score=1_000_000,
-            category=0,
+            category=models.Category.REGULAR,
             comment="鼻毛",
             video_link="",
             temp_replay_instance=temp_replay_1,
@@ -54,7 +50,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
             user=None,
             difficulty=0,
             score=0,
-            category=0,
+            category=models.Category.REGULAR,
             comment="Comment",
             video_link="",
             temp_replay_instance=temp_replay_2,
@@ -66,12 +62,11 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
             imported_username="あ",
         )
 
-        replays = models.Replay.objects.order_by("-score")
-        ranked_replays = add_rank_annotation_to_replays(replays)
+        replays = models.Replay.objects.order_by("-score").annotate_with_rank()
 
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = converter.convert_replays_to_serializable_list(ranked_replays)
+            json_data = converter.convert_replays_to_serializable_list(replays)
 
         assert len(json_data) == 2
 
@@ -112,11 +107,10 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
                     difficulty=0,
                 )
 
-        replays = models.Replay.objects.order_by("-score")
-        ranked_replays = add_rank_annotation_to_replays(replays)
+        replays = models.Replay.objects.order_by("-score").annotate_with_rank()
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = converter.convert_replays_to_serializable_list(ranked_replays)
+            json_data = converter.convert_replays_to_serializable_list(replays)
 
         self.assertEquals(json_data[0]["Score"]["text"], "🥇1,000,000,000")
         self.assertEquals(json_data[1]["Score"]["text"], "🥈900,000,000")
@@ -137,12 +131,11 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
                 difficulty=0,
             )
 
-        replays = models.Replay.objects.order_by("-score")
-        ranked_replays = add_rank_annotation_to_replays(replays)
+        replays = models.Replay.objects.order_by("-score").annotate_with_rank()
 
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = converter.convert_replays_to_serializable_list(ranked_replays)
+            json_data = converter.convert_replays_to_serializable_list(replays)
 
         self.assertEquals(json_data[0]["Score"]["text"], "🥇1,000,000,000")
         self.assertEquals(json_data[1]["Score"]["text"], "🥇900,000,000")

--- a/project/thscoreboard/replays/views/index.py
+++ b/project/thscoreboard/replays/views/index.py
@@ -5,19 +5,18 @@ from django.shortcuts import render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import (
-    ReplayToJsonConverter,
-    add_rank_annotation_to_replays,
-)
+from replays.replays_to_json import ReplayToJsonConverter
 
 
 @http_decorators.require_safe
 def index_json(request):
-    not_unusual_replays = models.Replay.objects.filter(
-        category__in=[models.Category.REGULAR, models.Category.TAS]
+    recent_replays = (
+        models.Replay.objects.filter(
+            category__in=[models.Category.REGULAR, models.Category.TAS]
+        )
+        .annotate_with_rank()
+        .order_by("-created")[:10]
     )
-    ranked_not_unusual_replays = add_rank_annotation_to_replays(not_unusual_replays)
-    recent_replays = ranked_not_unusual_replays.order_by("-created")[:10]
     converter = ReplayToJsonConverter()
     return JsonResponse(
         converter.convert_replays_to_serializable_list(recent_replays), safe=False

--- a/project/thscoreboard/replays/views/index.py
+++ b/project/thscoreboard/replays/views/index.py
@@ -5,14 +5,19 @@ from django.shortcuts import render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import ReplayToJsonConverter
+from replays.replays_to_json import (
+    ReplayToJsonConverter,
+    add_rank_annotation_to_replays,
+)
 
 
 @http_decorators.require_safe
 def index_json(request):
-    recent_replays = models.Replay.objects.filter(
+    not_unusual_replays = models.Replay.objects.filter(
         category__in=[models.Category.REGULAR, models.Category.TAS]
-    ).order_by("-created")[:10]
+    )
+    ranked_not_unusual_replays = add_rank_annotation_to_replays(not_unusual_replays)
+    recent_replays = ranked_not_unusual_replays.order_by("-created")[:10]
     converter = ReplayToJsonConverter()
     return JsonResponse(
         converter.convert_replays_to_serializable_list(recent_replays), safe=False

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -12,7 +12,7 @@ from replays.replays_to_json import ReplayToJsonConverter
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
-    converter = ReplayToJsonConverter()
+    converter = ReplayToJsonConverter(include_medals=True)
     return JsonResponse(
         converter.convert_replays_to_serializable_list(
             _get_all_replay_for_game(game_id)

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -4,19 +4,23 @@ from django.http import JsonResponse
 from django.views.decorators import http as http_decorators
 from django.shortcuts import get_object_or_404, render
 
+
 from replays import models
 from replays import game_ids
 from replays.models import Game, Shot, Route
-from replays.replays_to_json import ReplayToJsonConverter
+from replays.replays_to_json import (
+    ReplayToJsonConverter,
+    add_rank_annotation_to_replays,
+)
 
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
-    converter = ReplayToJsonConverter(include_medals=True)
+    converter = ReplayToJsonConverter()
+    replays = _get_all_replay_for_game(game_id)
+    ranked_replays = add_rank_annotation_to_replays(replays)
     return JsonResponse(
-        converter.convert_replays_to_serializable_list(
-            _get_all_replay_for_game(game_id)
-        ),
+        converter.convert_replays_to_serializable_list(ranked_replays),
         safe=False,
     )
 

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -8,19 +8,15 @@ from django.shortcuts import get_object_or_404, render
 from replays import models
 from replays import game_ids
 from replays.models import Game, Shot, Route
-from replays.replays_to_json import (
-    ReplayToJsonConverter,
-    add_rank_annotation_to_replays,
-)
+from replays.replays_to_json import ReplayToJsonConverter
 
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
     converter = ReplayToJsonConverter()
     replays = _get_all_replay_for_game(game_id)
-    ranked_replays = add_rank_annotation_to_replays(replays)
     return JsonResponse(
-        converter.convert_replays_to_serializable_list(ranked_replays),
+        converter.convert_replays_to_serializable_list(replays),
         safe=False,
     )
 
@@ -113,6 +109,7 @@ def _get_all_replay_for_game(game_id: str) -> dict:
         .filter(shot__game=game_id)
         .filter(replay_type=1)
         .order_by("-score")
+        .annotate_with_rank()
     )
 
 

--- a/project/thscoreboard/replays/views/user.py
+++ b/project/thscoreboard/replays/views/user.py
@@ -7,18 +7,23 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import ReplayToJsonConverter
+from replays.replays_to_json import (
+    ReplayToJsonConverter,
+    add_rank_annotation_to_replays,
+)
 
 
 @http_decorators.require_safe
 def user_page_json(request, username: str):
     user = get_object_or_404(auth.get_user_model(), username=username, is_active=True)
-    user_replays = models.Replay.objects.filter(user=user).order_by(
+    all_replays = models.Replay.objects
+    ranked_all_replays = add_rank_annotation_to_replays(all_replays)
+    ranked_user_replays = ranked_all_replays.filter(user=user).order_by(
         "shot__game_id", "shot_id", "created"
     )
     converter = ReplayToJsonConverter()
     return JsonResponse(
-        converter.convert_replays_to_serializable_list(user_replays), safe=False
+        converter.convert_replays_to_serializable_list(ranked_user_replays), safe=False
     )
 
 

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -134,7 +134,7 @@ function populateTable(replays, startIndex, endIndex) {
     const text = document.createTextNode(value);
     cell.appendChild(text);
   }
-  if (columnName === "Shot" || columnName === "Route") {
+  if (columnName === "Shot" || columnName === "Route" || columnName === "Score") {
     cell.className = "nowrap";
   } else if (columnName === "Comment") {
     cell.className = "comment-cell"


### PR DESCRIPTION
Add medal emojis (🥇, 🥈, 🥉) to the top 3 scores for a certain difficulty and shot.

![image](https://user-images.githubusercontent.com/44336657/233852541-f2f56dc3-2d91-4ab3-9a3d-634b3ec9f2ab.png)

In the future, I would like to add a player ranking by medal count, like royalflare had.