### PR TITLE
Fix user page rankings

### DIFF
--- a/project/thscoreboard/replays/rank_replays.py
+++ b/project/thscoreboard/replays/rank_replays.py
@@ -2,7 +2,7 @@ from replays import models
 from replays.models import ReplayQuerySet
 
 
-def add_global_rank_annotations(replays: ReplayQuerySet) -> None:
+def add_global_rank_annotations(replays: ReplayQuerySet) -> ReplayQuerySet:
     """Ranks replays in the replay query set against all ranked replays"""
     top_3_replays = (
         models.Replay.objects.filter(category=models.Category.STANDARD)

--- a/project/thscoreboard/replays/rank_replays.py
+++ b/project/thscoreboard/replays/rank_replays.py
@@ -1,0 +1,20 @@
+from replays import models
+from replays.models import ReplayQuerySet
+
+
+def add_global_rank_annotations(replays: ReplayQuerySet) -> None:
+    """Ranks replays in the replay query set against all ranked replays"""
+    top_3_replays = (
+        models.Replay.objects.filter(category=models.Category.STANDARD)
+        .filter(replay_type=1)
+        .filter(is_listed=True)
+        .annotate_with_rank()
+        .filter(rank__lte=3)
+        .all()
+    )
+    rank_dict = {replay.id: replay.rank for replay in top_3_replays}
+
+    for replay in replays:
+        replay.rank = rank_dict.get(replay.id, -1)
+
+    return replays

--- a/project/thscoreboard/replays/test_rank_replays.py
+++ b/project/thscoreboard/replays/test_rank_replays.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+from replays.rank_replays import add_global_rank_annotations
+from replays.testing import test_case
+from replays import models
+from replays.testing import test_replays
+
+
+class GlobalRankAnnotationsTestCase(test_case.ReplayTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.createUser("some-user")
+
+    def _create_n_replays(self, n: int, is_tas: bool = False) -> None:
+        for i in range(n):
+            with patch(
+                "replays.constant_helpers.CalculateReplayFileHash"
+            ) as mocked_hash:
+                mocked_hash.return_value = bytes(i)
+                test_replays.CreateAsPublishedReplay(
+                    "th10_normal",
+                    user=self.user,
+                    score=1_000_000_000 - 100_000_000 * i,
+                    difficulty=0,
+                    category=models.Category.TAS
+                    if is_tas
+                    else models.Category.STANDARD,
+                )
+
+    def testRanksAgainstAllReplays(self):
+        self._create_n_replays(3)
+        replay_subset = models.Replay.objects.order_by("-score")[1:]
+        add_global_rank_annotations(replay_subset)
+
+        self.assertEqual(replay_subset[0].rank, 2)
+        self.assertEqual(replay_subset[1].rank, 3)
+
+    def testGivesNegativeRankToReplaysOutsideTopThree(self):
+        self._create_n_replays(5)
+        replay_subset = models.Replay.objects.order_by("-score")[3:]
+        add_global_rank_annotations(replay_subset)
+
+        self.assertEqual(replay_subset[0].rank, -1)
+        self.assertEqual(replay_subset[1].rank, -1)
+
+    def testIgnoresUnrankedGlobalReplays(self):
+        self._create_n_replays(3, is_tas=True)
+        test_replays.CreateAsPublishedReplay(
+            "th10_normal", user=self.user, score=0, difficulty=0
+        )
+        replay_subset = models.Replay.objects.order_by("-score")[3:]
+        add_global_rank_annotations(replay_subset)
+
+        self.assertEqual(replay_subset[0].rank, 1)

--- a/project/thscoreboard/replays/test_rank_replays.py
+++ b/project/thscoreboard/replays/test_rank_replays.py
@@ -12,10 +12,8 @@ class GlobalRankAnnotationsTestCase(test_case.ReplayTestCase):
         self.user = self.createUser("some-user")
 
     def _create_n_replays(self, n: int, is_tas: bool = False) -> None:
-        for i in range(n):
-            with patch(
-                "replays.constant_helpers.CalculateReplayFileHash"
-            ) as mocked_hash:
+        with patch("replays.constant_helpers.CalculateReplayFileHash") as mocked_hash:
+            for i in range(n):
                 mocked_hash.return_value = bytes(i)
                 test_replays.CreateAsPublishedReplay(
                     "th10_normal",

--- a/project/thscoreboard/replays/views/user.py
+++ b/project/thscoreboard/replays/views/user.py
@@ -5,6 +5,7 @@ from django.contrib import auth
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators import http as http_decorators
 
+from replays.rank_replays import add_global_rank_annotations
 from replays import models
 from replays.replays_to_json import convert_replays_to_json_bytes
 from replays.views.replay_table_helpers import stream_json_bytes_to_http_reponse
@@ -16,19 +17,7 @@ def user_page_json(request, username: str):
     user_replays = models.Replay.objects.filter(user=user).order_by(
         "shot__game_id", "shot_id", "created"
     )
-
-    top_3_replays = (
-        models.Replay.objects.filter(category=models.Category.STANDARD)
-        .filter(replay_type=1)
-        .filter(is_listed=True)
-        .annotate_with_rank()
-        .filter(rank__lte=3)
-        .all()
-    )
-    rank_dict = {replay.id: replay.rank for replay in top_3_replays}
-
-    for replay in user_replays:
-        replay.rank = rank_dict.get(replay.id, -1)
+    add_global_rank_annotations(user_replays)
     replay_jsons = convert_replays_to_json_bytes(user_replays)
     return stream_json_bytes_to_http_reponse(replay_jsons)
 


### PR DESCRIPTION
Currently, we call `.annotate_with_rank().filter(user=user)` to try to get user replays ranked. This doesn't work though, as the rank will apply to the filtered replays. Not really sure why, I don't understand DB stuff.

As a workaround, store ranks for all replays in a python dict, then apply them to a filtered queryset. This is cringe. Performance dropped by about 200ms. I'm sure there's a better way but idk what it is.

Fixes #353