### PR TITLE
GZ compress replay response

### DIFF
--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -1,11 +1,8 @@
 """Contains views which list various replays."""
 
-import gzip
-import json
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.views.decorators import http as http_decorators
 from django.shortcuts import get_object_or_404, render
-
 
 from replays import models
 from replays import game_ids
@@ -15,13 +12,11 @@ from replays.replays_to_json import ReplayToJsonConverter
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
-    replays = _get_all_replay_for_game(game_id)
     converter = ReplayToJsonConverter()
-    replays_json = json.dumps(converter.convert_replays_to_serializable_list(replays))
-    replays_json_compressed = gzip.compress(replays_json.encode("utf-8"), 5)
-    response = HttpResponse(replays_json_compressed)
-    response["Content-Encoding"] = "gzip"
-    return response
+    replays = _get_all_replay_for_game(game_id)
+    return JsonResponse(
+        converter.convert_replays_to_serializable_list(replays), safe=False
+    )
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -1,6 +1,8 @@
 """Contains views which list various replays."""
 
-from django.http import JsonResponse
+import gzip
+import json
+from django.http import HttpResponse
 from django.views.decorators import http as http_decorators
 from django.shortcuts import get_object_or_404, render
 
@@ -13,12 +15,13 @@ from replays.replays_to_json import ReplayToJsonConverter
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
-    converter = ReplayToJsonConverter()
     replays = _get_all_replay_for_game(game_id)
-    return JsonResponse(
-        converter.convert_replays_to_serializable_list(replays),
-        safe=False,
-    )
+    converter = ReplayToJsonConverter()
+    replays_json = json.dumps(converter.convert_replays_to_serializable_list(replays))
+    replays_json_compressed = gzip.compress(replays_json.encode("utf-8"), 5)
+    response = HttpResponse(replays_json_compressed)
+    response["Content-Encoding"] = "gzip"
+    return response
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -12,29 +12,27 @@ var allReplays = [];
 
 requestAndInitializeReplays();
 
-function requestAndInitializeReplays() {
+async function requestAndInitializeReplays() {
   const requestUri = window.location.pathname === '/'
     ? window.location.origin + '/replays/index/json'
     : window.location.origin + window.location.pathname + "/json";
 
-  fetch(requestUri, {
-    headers: {
-      'Accept-Encoding': 'gzip'
-    },
-    priority: 'high'
-  })
-  .then(response => {
+  try {
+    const response = await fetch(requestUri, {
+      priority: 'high'
+    });
+
     if (!response.ok) {
       replayTableBodyHtml.innerHTML =
         '<p style="color: red;">Failed to load replays</p>';
+      return;
     }
-    return response.json();
-  })
-  .then(replayJson => {
-    allReplays = replayJson
+
+    const replayJson = await response.json();
+    allReplays = replayJson;
     const filteredReplays = filterReplays(activeFilters, allReplays);
     constructAndRenderReplayTable(filteredReplays);
-  }).catch(function() {});
+  } catch (error) {}
 }
 
 function onClick(elm) {

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -11,25 +11,33 @@ var activeFilters = {};
 var allReplays = [];
 
 try {
-  // initialize table content
-  const xhr = new XMLHttpRequest();
-  if(window.location.pathname === '/') {
-    xhr.open('GET', window.location.origin + '/replays/index/json', true);
-  } else {
-    xhr.open('GET', window.location.origin + window.location.pathname + "/json", true);
-  }
-  xhr.responseType = 'json';
-  xhr.onload = function() {
-    if (xhr.status === 200) {
-      allReplays = xhr.response;
-      constructAndRenderReplayTable(xhr.response);
-    } else {
-      document.getElementById('replay-table').innerHTML = '<p style="color: red;">Failed to load replays</p>';
-    }
-  };
-  xhr.send();
+  requestAndInitializeReplays();
 } catch(error) {
   // Catch ReferenceError for test suite but do nothing
+}
+
+function requestAndInitializeReplays() {
+  const requestUri = window.location.pathname === '/'
+    ? window.location.origin + '/replays/index/json'
+    : window.location.origin + window.location.pathname + "/json";
+
+  fetch(requestUri, {
+    headers: {
+      'Accept-Encoding': 'gzip'
+    }
+  })
+  .then(response => {
+    if (!response.ok) {
+      replayTableBodyHtml.innerHTML =
+        '<p style="color: red;">Failed to load replays</p>';
+    }
+    return response.json();
+  })
+  .then(replayJson => {
+    allReplays = replayJson
+    const filteredReplays = filterReplays(activeFilters, allReplays);
+    constructAndRenderReplayTable(filteredReplays);
+  });
 }
 
 function onClick(elm) {

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -24,7 +24,8 @@ function requestAndInitializeReplays() {
   fetch(requestUri, {
     headers: {
       'Accept-Encoding': 'gzip'
-    }
+    },
+    priority: 'high'
   })
   .then(response => {
     if (!response.ok) {

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -10,11 +10,7 @@ const displayedColumns = [
 var activeFilters = {};
 var allReplays = [];
 
-try {
-  requestAndInitializeReplays();
-} catch(error) {
-  // Catch ReferenceError for test suite but do nothing
-}
+requestAndInitializeReplays();
 
 function requestAndInitializeReplays() {
   const requestUri = window.location.pathname === '/'
@@ -38,7 +34,7 @@ function requestAndInitializeReplays() {
     allReplays = replayJson
     const filteredReplays = filterReplays(activeFilters, allReplays);
     constructAndRenderReplayTable(filteredReplays);
-  });
+  }).catch(function() {});
 }
 
 function onClick(elm) {

--- a/project/thscoreboard/thscoreboard/settings.py
+++ b/project/thscoreboard/thscoreboard/settings.py
@@ -265,3 +265,10 @@ else:
 
 DISCORD_WEBHOOK_ID = os.environ.get("DISCORD_WEBHOOK_ID", None)
 DISCORD_WEBHOOK_TOKEN = os.environ.get("DISCORD_WEBHOOK_TOKEN", None)
+
+MIDDLEWARE = [
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.gzip.GZipMiddleware",
+]

--- a/project/thscoreboard/thscoreboard/settings.py
+++ b/project/thscoreboard/thscoreboard/settings.py
@@ -106,6 +106,7 @@ MIDDLEWARE = [
     "users.middleware.check_ban.CheckBanMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django.middleware.gzip.GZipMiddleware",
 ]
 
 ROOT_URLCONF = "thscoreboard.urls"
@@ -265,10 +266,3 @@ else:
 
 DISCORD_WEBHOOK_ID = os.environ.get("DISCORD_WEBHOOK_ID", None)
 DISCORD_WEBHOOK_TOKEN = os.environ.get("DISCORD_WEBHOOK_TOKEN", None)
-
-MIDDLEWARE = [
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.gzip.GZipMiddleware",
-]

--- a/project/thscoreboard/thscoreboard/settings.py
+++ b/project/thscoreboard/thscoreboard/settings.py
@@ -95,6 +95,7 @@ INSTALLED_APPS = [
 ] + (DEV_ONLY_APPS if DEBUG else [])
 
 MIDDLEWARE = [
+    "django.middleware.gzip.GZipMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -106,7 +107,6 @@ MIDDLEWARE = [
     "users.middleware.check_ban.CheckBanMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.middleware.gzip.GZipMiddleware",
 ]
 
 ROOT_URLCONF = "thscoreboard.urls"


### PR DESCRIPTION
Use GZ to compress the json sent by the server. This reduces the amount of data sent by about 84%, or from 2.2MB to 350kB for IN.

Related: #370
Fixes #372