### PR TITLE
Delete backups more regularly (and delete them after 7 days).

### DIFF
--- a/ref/server/systemd/silentselene-delete-backups.service
+++ b/ref/server/systemd/silentselene-delete-backups.service
@@ -6,7 +6,7 @@ Wants=silentselene-delete-backups.timer
 Type=oneshot
 User=silentselene
 WorkingDirectory=/home/silentselene/backups/
-ExecStart=sh -c 'find /home/silentselene/backups/* -mtime +30 -daystart -exec rm {} \;'
+ExecStart=sh -c 'find /home/silentselene/backups/* -mtime +7 -daystart -exec rm {} \;'
 
 [Install]
 WantedBy=multi-user.target

--- a/ref/server/systemd/silentselene-delete-backups.timer
+++ b/ref/server/systemd/silentselene-delete-backups.timer
@@ -3,7 +3,7 @@ Description=silentselene: Clear out database backups older than a week
 Requires=silentselene-delete-backups.service
 
 [Timer]
-OnCalendar=monthly
+OnCalendar=hourly
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
This command is very cheap so there's no reason not to run it often.

#383