### PR TITLE
Stream replays from DB to frontend

### DIFF
--- a/project/thscoreboard/replays/replays_to_json.py
+++ b/project/thscoreboard/replays/replays_to_json.py
@@ -1,4 +1,5 @@
-from typing import Iterable
+import json
+from typing import Iterable, Iterator
 from functools import lru_cache
 
 from replays import models, game_ids
@@ -71,8 +72,10 @@ class ReplayToJsonConverter:
     def convert_replays_to_serializable_list(
         self,
         ranked_replays: Iterable[models.Replay],
-    ) -> list[dict[str, any]]:
-        return [self._convert_replay_to_dict(replay) for replay in ranked_replays]
+    ) -> Iterator[dict[str, any]]:
+        for replay in ranked_replays:
+            json_string = json.dumps(self._convert_replay_to_dict(replay))
+            yield f"{json_string}\n".encode("utf-8")
 
 
 def _get_medal_emoji(rank: int) -> str:

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -66,9 +66,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = [
-                converter._convert_replay_to_dict(replay) for replay in replays
-            ]
+            json_data = [converter.convert_replay_to_dict(replay) for replay in replays]
 
         for json_replay_data in json_data:
             assert json_replay_data
@@ -111,9 +109,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
         replays = models.Replay.objects.order_by("-score").annotate_with_rank()
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = [
-                converter._convert_replay_to_dict(replay) for replay in replays
-            ]
+            json_data = [converter.convert_replay_to_dict(replay) for replay in replays]
 
         self.assertEquals(json_data[0]["Score"]["text"], "🥇1,000,000,000")
         self.assertEquals(json_data[1]["Score"]["text"], "🥈900,000,000")
@@ -138,9 +134,7 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = [
-                converter._convert_replay_to_dict(replay) for replay in replays
-            ]
+            json_data = [converter.convert_replay_to_dict(replay) for replay in replays]
 
         self.assertEquals(json_data[0]["Score"]["text"], "🥇1,000,000,000")
         self.assertEquals(json_data[1]["Score"]["text"], "🥇900,000,000")

--- a/project/thscoreboard/replays/test_replays_to_json.py
+++ b/project/thscoreboard/replays/test_replays_to_json.py
@@ -66,9 +66,9 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = converter.convert_replays_to_serializable_list(replays)
-
-        assert len(json_data) == 2
+            json_data = [
+                converter._convert_replay_to_dict(replay) for replay in replays
+            ]
 
         for json_replay_data in json_data:
             assert json_replay_data
@@ -111,7 +111,9 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
         replays = models.Replay.objects.order_by("-score").annotate_with_rank()
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = converter.convert_replays_to_serializable_list(replays)
+            json_data = [
+                converter._convert_replay_to_dict(replay) for replay in replays
+            ]
 
         self.assertEquals(json_data[0]["Score"]["text"], "🥇1,000,000,000")
         self.assertEquals(json_data[1]["Score"]["text"], "🥈900,000,000")
@@ -136,7 +138,9 @@ class ReplaysToJsonTestCase(test_case.ReplayTestCase):
 
         with test_utilities.OverrideTranslations():
             converter = ReplayToJsonConverter()
-            json_data = converter.convert_replays_to_serializable_list(replays)
+            json_data = [
+                converter._convert_replay_to_dict(replay) for replay in replays
+            ]
 
         self.assertEquals(json_data[0]["Score"]["text"], "🥇1,000,000,000")
         self.assertEquals(json_data[1]["Score"]["text"], "🥇900,000,000")

--- a/project/thscoreboard/replays/views/index.py
+++ b/project/thscoreboard/replays/views/index.py
@@ -1,11 +1,13 @@
 """The front page of the website."""
 
-from django.http import JsonResponse
 from django.shortcuts import render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import ReplayToJsonConverter
+from replays.replays_to_json import (
+    convert_replays_to_json_strings,
+    stream_json_strings_to_http_reponse,
+)
 
 
 @http_decorators.require_safe
@@ -17,10 +19,8 @@ def index_json(request):
         .annotate_with_rank()
         .order_by("-created")[:10]
     )
-    converter = ReplayToJsonConverter()
-    return JsonResponse(
-        converter.convert_replays_to_serializable_list(recent_replays), safe=False
-    )
+    replay_jsons = convert_replays_to_json_strings(recent_replays)
+    return stream_json_strings_to_http_reponse(replay_jsons)
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/replays/views/index.py
+++ b/project/thscoreboard/replays/views/index.py
@@ -3,11 +3,9 @@
 from django.shortcuts import render
 from django.views.decorators import http as http_decorators
 
+from replays.views.replay_table_helpers import stream_json_bytes_to_http_reponse
 from replays import models
-from replays.replays_to_json import (
-    convert_replays_to_json_strings,
-    stream_json_strings_to_http_reponse,
-)
+from replays.replays_to_json import convert_replays_to_json_bytes
 
 
 @http_decorators.require_safe
@@ -19,8 +17,8 @@ def index_json(request):
         .annotate_with_rank()
         .order_by("-created")[:10]
     )
-    replay_jsons = convert_replays_to_json_strings(recent_replays)
-    return stream_json_strings_to_http_reponse(replay_jsons)
+    replay_jsons = convert_replays_to_json_bytes(recent_replays)
+    return stream_json_bytes_to_http_reponse(replay_jsons)
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -1,6 +1,6 @@
 """Contains views which list various replays."""
 
-from django.http import JsonResponse
+from django.http import StreamingHttpResponse
 from django.views.decorators import http as http_decorators
 from django.shortcuts import get_object_or_404, render
 
@@ -12,11 +12,14 @@ from replays.replays_to_json import ReplayToJsonConverter
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
-    converter = ReplayToJsonConverter()
     replays = _get_all_replay_for_game(game_id)
-    return JsonResponse(
-        converter.convert_replays_to_serializable_list(replays), safe=False
+    converter = ReplayToJsonConverter()
+    response = StreamingHttpResponse(
+        converter.convert_replays_to_serializable_list(replays),
+        content_type="application/json",
     )
+    response["Content-Disposition"] = 'attachment; filename="output.json"'
+    return response
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -6,17 +6,15 @@ from django.shortcuts import get_object_or_404, render
 from replays import models
 from replays import game_ids
 from replays.models import Game, Shot, Route
-from replays.replays_to_json import (
-    convert_replays_to_json_strings,
-    stream_json_strings_to_http_reponse,
-)
+from replays.replays_to_json import convert_replays_to_json_bytes
+from replays.views.replay_table_helpers import stream_json_bytes_to_http_reponse
 
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
     replays = _get_all_replay_for_game(game_id)
-    replay_jsons = convert_replays_to_json_strings(replays)
-    return stream_json_strings_to_http_reponse(replay_jsons)
+    replay_jsons = convert_replays_to_json_bytes(replays)
+    return stream_json_bytes_to_http_reponse(replay_jsons)
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -1,25 +1,22 @@
 """Contains views which list various replays."""
 
-from django.http import StreamingHttpResponse
 from django.views.decorators import http as http_decorators
 from django.shortcuts import get_object_or_404, render
 
 from replays import models
 from replays import game_ids
 from replays.models import Game, Shot, Route
-from replays.replays_to_json import ReplayToJsonConverter
+from replays.replays_to_json import (
+    convert_replays_to_json_strings,
+    stream_json_strings_to_http_reponse,
+)
 
 
 @http_decorators.require_safe
 def game_scoreboard_json(request, game_id: str):
     replays = _get_all_replay_for_game(game_id)
-    converter = ReplayToJsonConverter()
-    response = StreamingHttpResponse(
-        converter.convert_replays_to_serializable_list(replays),
-        content_type="application/json",
-    )
-    response["Content-Disposition"] = 'attachment; filename="output.json"'
-    return response
+    replay_jsons = convert_replays_to_json_strings(replays)
+    return stream_json_strings_to_http_reponse(replay_jsons)
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/replays/views/replay_table_helpers.py
+++ b/project/thscoreboard/replays/views/replay_table_helpers.py
@@ -1,0 +1,13 @@
+from typing import Iterable
+from django.http import StreamingHttpResponse
+
+
+def stream_json_bytes_to_http_reponse(
+    replay_bytes: Iterable[bytes],
+) -> StreamingHttpResponse:
+    response = StreamingHttpResponse(
+        iter(replay_bytes),
+        content_type="application/json",
+    )
+    response["Content-Disposition"] = 'attachment; filename="output.json"'
+    return response

--- a/project/thscoreboard/replays/views/user.py
+++ b/project/thscoreboard/replays/views/user.py
@@ -2,12 +2,14 @@
 
 
 from django.contrib import auth
-from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import ReplayToJsonConverter
+from replays.replays_to_json import (
+    convert_replays_to_json_strings,
+    stream_json_strings_to_http_reponse,
+)
 
 
 @http_decorators.require_safe
@@ -16,10 +18,8 @@ def user_page_json(request, username: str):
     user_replays = models.Replay.objects.filter(user=user).order_by(
         "shot__game_id", "shot_id", "created"
     )
-    converter = ReplayToJsonConverter()
-    return JsonResponse(
-        converter.convert_replays_to_serializable_list(user_replays), safe=False
-    )
+    replay_jsons = convert_replays_to_json_strings(user_replays)
+    return stream_json_strings_to_http_reponse(replay_jsons)
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/replays/views/user.py
+++ b/project/thscoreboard/replays/views/user.py
@@ -6,10 +6,8 @@ from django.shortcuts import get_object_or_404, render
 from django.views.decorators import http as http_decorators
 
 from replays import models
-from replays.replays_to_json import (
-    convert_replays_to_json_strings,
-    stream_json_strings_to_http_reponse,
-)
+from replays.replays_to_json import convert_replays_to_json_bytes
+from replays.views.replay_table_helpers import stream_json_bytes_to_http_reponse
 
 
 @http_decorators.require_safe
@@ -18,8 +16,8 @@ def user_page_json(request, username: str):
     user_replays = models.Replay.objects.filter(user=user).order_by(
         "shot__game_id", "shot_id", "created"
     )
-    replay_jsons = convert_replays_to_json_strings(user_replays)
-    return stream_json_strings_to_http_reponse(replay_jsons)
+    replay_jsons = convert_replays_to_json_bytes(user_replays)
+    return stream_json_bytes_to_http_reponse(replay_jsons)
 
 
 @http_decorators.require_safe

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -4,11 +4,9 @@ const displayedColumns = [
   "User", "Game", "Difficulty", "Shot", "Route", "Score", "Upload Date", "Comment", "Replay"
 ];
 
-// Initialize global variables if they were not provided by html
-// Needed for jest environment
-
 var activeFilters = {};
 var allReplays = [];
+var tableResetCounter = 0;
 
 requestAndInitializeReplays();
 
@@ -18,9 +16,8 @@ async function requestAndInitializeReplays() {
     : window.location.origin + window.location.pathname + "/json";
 
   try {
-    const response = await fetch(requestUri, {
-      priority: 'high'
-    });
+    console.log('', Date.now()/1000, "Sending request");
+    const response = await fetch(requestUri, {priority: 'high'});
 
     if (!response.ok) {
       replayTableBodyHtml.innerHTML =
@@ -35,25 +32,25 @@ async function requestAndInitializeReplays() {
     while (true) {
       const { done, value } = await reader.read();
       if (done) {
-        console.log("Finished consuming the response");
+        console.log('', Date.now()/1000, "Got all replays");
         return;
       }
 
       buffer += decoder.decode(value, { stream: true });
       const jsonStrings = buffer.split('\n');
-      console.log("Got new buffer section containing:", jsonStrings.length);
-  
-      // process complete JSON objects
+      console.log('', Date.now()/1000, "Got new buffer section containing:", jsonStrings.length, "replays");
+
+      const newReplays = [];
       while (jsonStrings.length > 1) {
         const jsonString = jsonStrings.shift();
-        const jsonObj = JSON.parse(jsonString);
-        allReplays.push(jsonObj);
+        const replay = JSON.parse(jsonString);
+        newReplays.push(replay);
       }
-  
-      buffer = jsonStrings[0] || ''; // keep incomplete JSON string for next iteration
-      const filteredReplays = filterReplays(activeFilters, allReplays);
-      constructAndRenderReplayTable(filteredReplays);
-      console.log("All replays", allReplays.length);
+      // The final string might be incomplete, so instead of parsing it we store it in the buffer
+      buffer = jsonStrings[0] || '';
+
+      addReplaysToTable(filterReplays(activeFilters, newReplays));
+      allReplays.push(...newReplays);
     }
 
   } catch (error) {}
@@ -65,7 +62,8 @@ function onClick(elm) {
 
   activeFilters = updateFilters(activeFilters, filterType, value);
   const filteredReplays = filterReplays(activeFilters, allReplays);
-  constructAndRenderReplayTable(filteredReplays);
+  clearTableHtml();
+  addReplaysToTable(filteredReplays);
 }
 
 function updateFilters(filters, filterType, value) {
@@ -95,15 +93,12 @@ function filterReplays(filters, replays) {
   return filteredReplays;
 }
 
-function constructAndRenderReplayTable(replays) {
-  clearTableHtml();
-
+function addReplaysToTable(replays){
   let startIndex = 0;
   let endIndex = Math.min(replayTableBatchSize, replays.length);
   while (startIndex < replays.length) {
-    isFirstBatch = startIndex === 0;
     constructAndRenderTableBatch(
-      replays, startIndex, endIndex, isFirstBatch
+      replays, startIndex, endIndex
     );
     startIndex += replayTableBatchSize;
     endIndex += replayTableBatchSize;
@@ -111,19 +106,18 @@ function constructAndRenderReplayTable(replays) {
   }
 }
 
-function constructAndRenderTableBatch(replays, startIndex, endIndex, isFirstBatch) {
-  if (isFirstBatch) {
-    populateTable(replays, startIndex, endIndex);
-  } else {
-    delayedPopulateTable(replays, startIndex, endIndex);
-  }
-}
-
-function delayedPopulateTable(replays, startIndex, endIndex) {
+function constructAndRenderTableBatch(replays, startIndex, endIndex) {
+  const tableResetsAtSchedulingTime = tableResetCounter;
   // Delays the execution of the populateTable function to prevent blocking the
   // main thread and improve performance. This allows other code to run, such
   // as UI updates, while the table is being populated.
   setTimeout(() => {
+    const tableResetsAtCallTime = tableResetCounter;
+    if (tableResetsAtCallTime != tableResetsAtSchedulingTime) {
+      // table was reset, call is invalid
+      return;
+    }
+
     populateTable(replays, startIndex, endIndex)
   }, 1);
 }
@@ -179,6 +173,7 @@ function createLink(url, text) {
 
 function clearTableHtml() {
   replayTableBodyHtml.innerHTML = '';
+  tableResetCounter++;
 }
 
 try {


### PR DESCRIPTION
Stream the replays from the database query all the way to displaying it in the user's browser. This should improve performance, especially when a lot of replays are requested.

It's hard to measure the impact of this change, because performance is fine locally. I tried testing the code using every replay in my DB (50,000 total), but the numbers don't mean much:
Before: Replays appear after 1747ms
After: Replays appear after 923ms
I would like to push this to staging with javascript logging so that we can better understand what it does and see its impact.