### PR TITLE
Allow hints in rules for th11

### DIFF
--- a/project/thscoreboard/replays/templates/replays/docs/replay_rules.html
+++ b/project/thscoreboard/replays/templates/replays/docs/replay_rules.html
@@ -89,7 +89,7 @@
             <b>TH10</b>: "Hint files" are allowed.
         </li>
         <li>
-            <b>TH11</b>: "Hint files" are not allowed.
+            <b>TH11</b>: "Hint files" are allowed.
         </li>
     </ul>
     {% endblocktranslate %}


### PR DESCRIPTION
I think they should be allowed. Copying what I wrote on the discord:

I think that's something we should allow
main reason is that the community is generally going in the direction of accepting hint files
me & feli used them in our wr's, iirc there were more
nyanko's sa tournament allows them
in twc, i think there was no decision from the staff and it was discussed with the players (idk the outcome but i didnt notice any hints being used)
i think not allowing those replays on silentselene goes against community interests