### PR TITLE
Show a more helpful error on duplicate replay upload

### DIFF
--- a/project/thscoreboard/replays/constant_helpers.py
+++ b/project/thscoreboard/replays/constant_helpers.py
@@ -44,9 +44,9 @@ def GetModelInstancesForReplay(
     return ReplayConstantModels(game=shot.game, shot=shot, route=route)
 
 
-def CheckReplayFileDuplicate(file):
+def GetReplayFileWithSameHash(file) -> Optional[models.ReplayFile]:
     hash = CalculateReplayFileHash(file)
-    return models.ReplayFile.objects.filter(replay_hash=hash).exists()
+    return models.ReplayFile.objects.filter(replay_hash=hash).first()
 
 
 def CalculateReplayFileHash(file):

--- a/project/thscoreboard/replays/management/commands/import_royalflare.py
+++ b/project/thscoreboard/replays/management/commands/import_royalflare.py
@@ -69,7 +69,8 @@ def import_royalflare(info_from_json: dict, replay_dir: Path) -> None:
         if replay_path.stat().st_size > limits.MAX_REPLAY_SIZE:
             raise limits.FileTooBigError()
         replay_bytes = replay_path.read_bytes()
-        if constant_helpers.CheckReplayFileDuplicate(replay_bytes):
+        duplicate = constant_helpers.GetReplayFileWithSameHash(replay_bytes)
+        if duplicate is not None:
             raise Exception("This replay already exists")
         replay_info = replay_parsing.Parse(replay_bytes)
         temp_replay = models.TemporaryReplayFile(user=None, replay=replay_bytes)

--- a/project/thscoreboard/replays/test_create_replay.py
+++ b/project/thscoreboard/replays/test_create_replay.py
@@ -232,14 +232,14 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
     def testReplayDuplicates(self):
         replay_file_contents = test_replays.GetRaw("th10_normal")
 
-        temp_replay = models.TemporaryReplayFile(
+        temp_replay_1 = models.TemporaryReplayFile(
             user=self.user, replay=replay_file_contents
         )
-        temp_replay.save()
+        temp_replay_1.save()
 
         replay_info = replay_parsing.Parse(replay_file_contents)
 
-        create_replay.PublishNewReplay(
+        replay_1 = create_replay.PublishNewReplay(
             user=self.user,
             difficulty=3,
             score=294127890,
@@ -250,14 +250,14 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
             is_clear=True,
             no_bomb=False,
             miss_count=None,
-            temp_replay_instance=temp_replay,
+            temp_replay_instance=temp_replay_1,
             replay_info=replay_info,
         )
 
-        temp_replay = models.TemporaryReplayFile(
+        temp_replay_2 = models.TemporaryReplayFile(
             user=self.user, replay=replay_file_contents
         )
-        temp_replay.save()
+        temp_replay_2.save()
 
         replay_info = replay_parsing.Parse(replay_file_contents)
 
@@ -273,10 +273,11 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
                 is_clear=True,
                 no_bomb=False,
                 miss_count=None,
-                temp_replay_instance=temp_replay,
+                temp_replay_instance=temp_replay_2,
                 replay_info=replay_info,
             )
 
         self.assertEqual(
-            constant_helpers.CheckReplayFileDuplicate(replay_file_contents), True
+            constant_helpers.GetReplayFileWithSameHash(replay_file_contents).replay,
+            replay_1,
         )

--- a/project/thscoreboard/replays/views/create_replay.py
+++ b/project/thscoreboard/replays/views/create_replay.py
@@ -34,8 +34,11 @@ def _HandleReplay(request, replay_bytes):
     """
 
     # test if replay already exists, and return an error if so
-    if constant_helpers.CheckReplayFileDuplicate(replay_bytes):
-        raise ValidationError("This replay already exists")
+    duplicate = constant_helpers.GetReplayFileWithSameHash(replay_bytes)
+    if duplicate is not None:
+        raise ValidationError(
+            f"This replay already exists. /replays/{duplicate.replay.shot.game.game_id}/{duplicate.replay.id}"
+        )
 
     try:
         return replay_parsing.Parse(replay_bytes)
@@ -104,7 +107,8 @@ def publish_replay(request, temp_replay_id):
         )
 
         # test if replay already exists, and return an error if so
-        if constant_helpers.CheckReplayFileDuplicate(temp_replay.replay):
+        duplicate = constant_helpers.GetReplayFileWithSameHash(temp_replay.replay)
+        if duplicate is not None:
             # if the temp replay doesn't exist anymore, the user can't even get to this page so this code doesn't really help
             # when submitting twice
             # but I'll keep it in here for potential situations I haven't thought of


### PR DESCRIPTION
I want to add unlisted replays. But then, a replay could be rejected for being a duplicate of a replay not shown on the leaderboards. This might cause some confusion. Therefore, we should at least tell the uploader where the duplicate replay is.

The new error message is: "This replay already exists. /replays/th08/18"
Consider the message temporary. I didn't want to write any new html, but felt that it was necessary to display the info in some form.