### PR TITLE
Allow users to unclaim replays

### DIFF
--- a/project/thscoreboard/replays/templates/replays/replay_details.html
+++ b/project/thscoreboard/replays/templates/replays/replay_details.html
@@ -120,6 +120,11 @@
         <a href="{{replay.video_link}}">Watch replay on external site</a>
     </div>
     {% endif %}
+    {% if can_remove_claim %}
+    <div>
+        <a href="/replays/{{ game_id }}/{{ replay.id }}/unclaim_replay">Unclaim this replay</a>
+    </div>
+    {% endif %}
     {% if can_delete %}
     <div>
         <a href="/replays/{{ game_id }}/{{ replay.id }}/delete">Permanently delete this replay</a>

--- a/project/thscoreboard/replays/templates/replays/unclaim_replay.html
+++ b/project/thscoreboard/replays/templates/replays/unclaim_replay.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load humanize %}
+
+{% block content %}
+    <h2>{{ game_name }}</h2>
+    <h3>{{ difficulty_name }} -- {{ shot_name }}</h3>
+    <div class="replay-box">
+        Original username: <span>{{ replay.imported_username }}</span>
+    </div>
+    <div class="replay-box">
+        Total score: <span class="replay-score">{{ replay.score|intcomma }}</span>
+    </div>
+    <p>Are you sure that this replay does not belong to you?</p>
+    <form method="post">
+        {% csrf_token %}
+        <button name="unclaim">Yes!</button>
+    </form>
+{% endblock %}

--- a/project/thscoreboard/replays/urls/replay_urls.py
+++ b/project/thscoreboard/replays/urls/replay_urls.py
@@ -34,4 +34,5 @@ urlpatterns = [
         view_replay.view_replay_reanalysis,
         name="Replays/Reanalysis",
     ),
+    path("<str:game_id>/<int:replay_id>/unclaim_replay", view_replay.unclaim_replay),
 ]

--- a/project/thscoreboard/replays/views/view_replay.py
+++ b/project/thscoreboard/replays/views/view_replay.py
@@ -53,6 +53,10 @@ def replay_details(request, game_id: str, replay_id: int):
 
     edit_form = forms.EditReplayForm(initial={"comment": replay_instance.comment})
 
+    can_remove_claim = _is_replay_claimed(replay_instance) and (
+        request.user == replay_instance.user or request.user.is_staff
+    )
+
     context = {
         "game_name": replay_instance.shot.game.GetName(),
         "shot_name": replay_instance.shot.GetName(),
@@ -69,6 +73,7 @@ def replay_details(request, game_id: str, replay_id: int):
         "edit_form": edit_form,
         "replay_type": game_ids.GetReplayType(replay_instance.replay_type),
         "site_base": settings.SITE_BASE,
+        "can_remove_claim": can_remove_claim,
     }
 
     if hasattr(replay_instance, "replayfile"):
@@ -158,7 +163,36 @@ def delete_replay(request, game_id: str, replay_id: int):
     )
 
 
-def GetReplayOr404(user, replay_id):
+@http_decorators.require_http_methods(["GET", "HEAD", "POST"])
+@auth_decorators.login_required
+def unclaim_replay(request, game_id: str, replay_id: int):
+    replay_instance = GetReplayOr404(request.user, replay_id)
+
+    if replay_instance.shot.game.game_id != game_id:
+        raise Http404()
+    if not _is_replay_claimed(replay_instance):
+        return HttpResponseBadRequest()
+    if not replay_instance.user == request.user and not request.user.is_staff:
+        return HttpResponseForbidden()
+
+    if request.method == "POST":
+        replay_instance.user = None
+        replay_instance.save()
+        return redirect(f"/replays/{game_id}/{replay_id}")
+
+    return render(
+        request,
+        "replays/unclaim_replay.html",
+        {
+            "game_name": replay_instance.shot.game.GetName(),
+            "shot_name": replay_instance.shot.GetName(),
+            "difficulty_name": replay_instance.GetDifficultyName(),
+            "replay": replay_instance,
+        },
+    )
+
+
+def GetReplayOr404(user, replay_id: int) -> models.Replay:
     try:
         replay_instance = (
             models.Replay.objects.select_related("shot")
@@ -184,3 +218,7 @@ def GetReplayWithStagesOr404(
         raise Http404()
     replay_stages = models.ReplayStage.objects.filter(replay=replay_id)
     return replay_instance, replay_stages
+
+
+def _is_replay_claimed(replay: models.Replay) -> bool:
+    return replay.imported_username is not None and replay.user is not None

--- a/project/thscoreboard/replays/views/view_replay.py
+++ b/project/thscoreboard/replays/views/view_replay.py
@@ -95,7 +95,7 @@ def view_replay_reanalysis(request, game_id: str, replay_id: int):
     if replay_instance.shot.game.game_id != game_id:
         raise Http404()
     if not replay_instance.shot.game.has_replays:
-        raise HttpResponseBadRequest()
+        return HttpResponseBadRequest()
 
     if request.method == "POST":
         reanalyze_replay.UpdateReplay(replay_id)
@@ -121,7 +121,7 @@ def download_replay(request, game_id: str, replay_id: int):
     if replay_instance.shot.game.game_id != game_id:
         raise Http404()
     if not replay_instance.shot.game.has_replays:
-        raise HttpResponseBadRequest()
+        return HttpResponseBadRequest()
 
     try:
         replay_file_instance = models.ReplayFile.objects.get(replay=replay_instance)
@@ -145,7 +145,7 @@ def delete_replay(request, game_id: str, replay_id: int):
     if replay_instance.shot.game.game_id != game_id:
         raise Http404()
     if not replay_instance.user == request.user and not request.user.is_staff:
-        raise HttpResponseForbidden()
+        return HttpResponseForbidden()
 
     if request.method == "POST":
         replay_instance.delete()


### PR DESCRIPTION
Adds a new button to unclaim replays. This button is visible only if:
1. The replay is imported
1. The replay is claimed
1. The user owns the replay or is staff

After clicking it, you are redirected to a confirmation page:
![image](https://github.com/n-rook/thscoreboard/assets/44336657/b3806bb6-cedf-48eb-9099-b73a3dd6bcc0)
Confirming executes the action.