### PR TITLE
Split large checkbox lists into columns of 4

### DIFF
--- a/project/thscoreboard/replays/templates/replays/game_scoreboard.html
+++ b/project/thscoreboard/replays/templates/replays/game_scoreboard.html
@@ -4,7 +4,7 @@
     <h2><a href="/replays/{{game.game_id}}">{{ game.GetFullName }}</a></h2>
 
     {% for filter_name, filter_values in filters.items %}
-        <div class="checkbox-list">
+        <div class="{% if filter_values|length >= 8 %}checkbox-list-4rows{% else %}checkbox-list{% endif %}">
             {% for filter_value in filter_values %}
                 <label><input
                     type="checkbox"
@@ -15,7 +15,6 @@
             {% endfor %}
         </div>
     {% endfor %}
-
     <br />
 
     {% include "replays/replay_table.html" %}

--- a/project/thscoreboard/shared_content/static/style.sass
+++ b/project/thscoreboard/shared_content/static/style.sass
@@ -287,6 +287,17 @@ input
     text-decoration: none
     color: inherit
 
+.checkbox-list-4rows
+    display: inline-grid
+    grid-template-rows: repeat(4, minmax(0, 1fr))
+    grid-auto-flow: column
+    margin-right: 50px
+    margin-bottom: 20px
+    line-height: 1.15
+    
+.checkbox-list-4rows label
+    margin-right: 20px
+
 .checkbox-list
     display: inline-block
     vertical-align: top


### PR DESCRIPTION
Styling change. th08 and th09 have long shot lists, which occupy a large part of the screen. Therefore, I split them into columns of 4.
![image](https://github.com/n-rook/thscoreboard/assets/44336657/cdc1bd6d-f8a4-4522-a910-d95cef82bbd2)
![image](https://github.com/n-rook/thscoreboard/assets/44336657/537a94a5-23e6-4fa8-94c0-025644648b42)
