### PR TITLE
Create a page to view all replay claim requests

### DIFF
--- a/project/thscoreboard/replays/templates/replays/claim_username.html
+++ b/project/thscoreboard/replays/templates/replays/claim_username.html
@@ -1,9 +1,10 @@
 {% extends "simple_centered.html" %}
 {% load i18n %}
 
-{% block centered-title %}<p>Claim a username</p>{% endblock %}
+{% block centered-title %}<p>Claim replays</p>{% endblock %}
 
 {% block centered-content %}
+    <a href="my_claims">My claims</a>
     <form method="post">
         {% csrf_token %}
         {% if user.is_staff %}

--- a/project/thscoreboard/replays/templates/replays/my_claims.html
+++ b/project/thscoreboard/replays/templates/replays/my_claims.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+
+{% if user.is_staff %}
+<h2>
+    All claims
+</h2>
+{% else %}
+<h2>
+    My claims
+</h2>
+{% endif %}
+<table class="replay-table">
+    <thead>
+        <tr>
+            <th>Id</th>
+            <th>User</th>
+            <th>Status</th>
+            <th>Link</th>
+        </tr>
+    </thead>
+    {% for claim_request in claim_requests %}
+        <tr>
+            <td>{{ claim_request.id }}</td>
+            <td>{{ claim_request.user.get_username }}</td>
+            <td>{{ claim_request.get_request_status_name }}</td>
+            <td><a href="claim/{{ claim_request.id }}">View</a></td>
+        </tr>
+    {% endfor %}
+</table>
+
+{% endblock %}

--- a/project/thscoreboard/thscoreboard/templates/staff.html
+++ b/project/thscoreboard/thscoreboard/templates/staff.html
@@ -13,6 +13,7 @@
         <li><a href="/users/ip_bans">IP Bans</a></li>
         <li><a href="/users/batch_invite">Batch invite</a></li>
         <li><a href="/replays/reanalyze_all">Reanalyze all replays</a></li>
+        <li><a href="/users/my_claims">See all replay claims</a></li>
         <br>
     {% endif %}
     {% if user.is_superuser %}

--- a/project/thscoreboard/users/models.py
+++ b/project/thscoreboard/users/models.py
@@ -636,3 +636,22 @@ class ClaimReplayRequest(models.Model):
 
     request_status = models.IntegerField(choices=RequestStatus.choices)
     """The status of this request."""
+
+    def is_visible_to(self, user: User) -> bool:
+        if user.is_staff:
+            return True
+        if user == self.user and self.request_status == RequestStatus.SUBMITTED:
+            return True
+        return False
+
+    def get_request_status_name(self) -> str:
+        if self.request_status == RequestStatus.SUBMITTED:
+            return "Submitted"
+        elif self.request_status == RequestStatus.APPROVED:
+            return "Approved"
+        elif self.request_status == RequestStatus.USER_DELETED:
+            return "Deleted by user"
+        elif self.request_status == RequestStatus.STAFF_DELETED:
+            return "Deleted by staff"
+        else:
+            return "Error"

--- a/project/thscoreboard/users/test_claim.py
+++ b/project/thscoreboard/users/test_claim.py
@@ -62,7 +62,10 @@ class ClaimReplaysTest(ReplayTestCase):
             },
         )
 
-        self.assertContains(response, "Success!")
+        self.assertRedirects(
+            response, "/users/my_claims", fetch_redirect_response=False
+        )
+
         claim_replay_request = user_models.ClaimReplayRequest.objects.first()
         self.assertEqual(claim_replay_request.user, self.user)
         self.assertEqual(claim_replay_request.contact_info, "contact info")

--- a/project/thscoreboard/users/urls.py
+++ b/project/thscoreboard/users/urls.py
@@ -12,6 +12,7 @@ from users.views import (
     register,
     claim,
     set_language,
+    my_claims,
 )
 
 from thscoreboard import settings
@@ -84,4 +85,5 @@ urlpatterns = [
     path("claim", claim.claim),
     path("set_language", set_language.set_language),
     path("claim/<int:claim_replay_request_id>", claim.review),
+    path("my_claims", my_claims.my_claims),
 ]

--- a/project/thscoreboard/users/views/claim.py
+++ b/project/thscoreboard/users/views/claim.py
@@ -1,5 +1,5 @@
 from typing import Iterable, Optional, Tuple
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.contrib.auth import decorators as auth_decorators
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import Http404, HttpResponse
@@ -36,7 +36,9 @@ def claim(request: WSGIRequest) -> HttpResponse:
                 is_request_from_staff=request.user.is_staff,
                 contact_info=form.cleaned_data["contact_info"],
             )
-            return render(request, "replays/success.html")
+            if request.user.is_staff:
+                return render(request, "replays/success.html")
+            return redirect("/users/my_claims")
 
 
 @auth_decorators.login_required

--- a/project/thscoreboard/users/views/my_claims.py
+++ b/project/thscoreboard/users/views/my_claims.py
@@ -1,0 +1,19 @@
+from django.shortcuts import render
+from django.contrib.auth import decorators as auth_decorators
+from django.core.handlers.wsgi import WSGIRequest
+from django.http import HttpResponse
+
+
+import users.models as user_models
+
+
+@auth_decorators.login_required
+def my_claims(request: WSGIRequest) -> HttpResponse:
+    claim_requests = user_models.ClaimReplayRequest.objects.all()
+    if not request.user.is_staff:
+        claim_requests = claim_requests.filter(user=request.user).all()
+    return render(
+        request,
+        "replays/my_claims.html",
+        {"claim_requests": claim_requests},
+    )

--- a/project/thscoreboard/users/views/my_claims.py
+++ b/project/thscoreboard/users/views/my_claims.py
@@ -3,13 +3,12 @@ from django.contrib.auth import decorators as auth_decorators
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
 
-
 import users.models as user_models
 
 
 @auth_decorators.login_required
 def my_claims(request: WSGIRequest) -> HttpResponse:
-    claim_requests = user_models.ClaimReplayRequest.objects.all()
+    claim_requests = user_models.ClaimReplayRequest.objects.order_by("id")
     if not request.user.is_staff:
         claim_requests = claim_requests.filter(user=request.user).all()
     return render(


### PR DESCRIPTION
Adds a page users/my_claims which gives basic details about all claims.

Non-staff will only see their own claims requests, staff will see everything.

![image](https://github.com/n-rook/thscoreboard/assets/44336657/bb0d81ba-fb0a-409f-b7f7-79757f20dd84)
