### PR TITLE
Only show 'Claim replays from royalflare' link on own profile

### DIFF
--- a/project/thscoreboard/replays/templates/replays/user_page.html
+++ b/project/thscoreboard/replays/templates/replays/user_page.html
@@ -3,5 +3,7 @@
 {% block content %}
     <h2>{{viewed_user.username}}</h2>
     {% include "replays/replay_table.html" with show_game=True %}
-    <p><a href="/users/claim">Claim replays from royalflare</a></p>
+    {% if is_own_page %}
+        <p><a href="/users/claim">Claim replays from royalflare</a></p>
+    {% endif %}
 {% endblock %}

--- a/project/thscoreboard/replays/views/user.py
+++ b/project/thscoreboard/replays/views/user.py
@@ -23,9 +23,10 @@ def user_page_json(request, username: str):
 @http_decorators.require_safe
 def user_page(request, username: str):
     user = get_object_or_404(auth.get_user_model(), username=username, is_active=True)
+    is_own_page = user == request.user
 
     return render(
         request,
         "replays/user_page.html",
-        {"viewed_user": user},
+        {"viewed_user": user, "is_own_page": is_own_page},
     )


### PR DESCRIPTION
Bugfix. The 'Claim replays from royalflare' link at the bottom of the user profile should only be seen when viewing your own profile.