### PR TITLE
Allow 0 replays in ClaimReplaysForm

### DIFF
--- a/project/thscoreboard/users/forms.py
+++ b/project/thscoreboard/users/forms.py
@@ -192,7 +192,7 @@ class ClaimReplaysForm(forms.Form):
         CONFIRM = "Confirm"
 
     choices = forms.MultipleChoiceField(
-        widget=forms.CheckboxSelectMultiple,
+        widget=forms.CheckboxSelectMultiple, required=False
     )
     contact_info = forms.CharField(
         label=_("contact_info"), required=True, max_length=200


### PR DESCRIPTION
Context: After re-importing replays, we ended up with some claim requests that have no replays attached to them. The form gives an error when we try to delete them. Therefore, I make the replays ChoiceField optional.