### PR TITLE
Sort tied replays by upload time

### DIFF
--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -209,6 +209,7 @@ class ReplayQuerySet(QuerySet):
                         order_by=[
                             F("score").desc(),
                             F("created"),
+                            F("id"),
                         ],
                         partition_by=[
                             F("shot_id"),

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -206,7 +206,10 @@ class ReplayQuerySet(QuerySet):
                     category=Category.STANDARD,
                     then=Window(
                         expression=RowNumber(),
-                        order_by=F("score").desc(),
+                        order_by=[
+                            F("score").desc(),
+                            F("created"),
+                        ],
                         partition_by=[
                             F("shot_id"),
                             F("difficulty"),

--- a/project/thscoreboard/replays/testing/test_replays.py
+++ b/project/thscoreboard/replays/testing/test_replays.py
@@ -1,5 +1,6 @@
 """Makes some replays available for tests."""
 
+import datetime
 from pathlib import Path
 import typing
 
@@ -47,6 +48,7 @@ def CreateAsPublishedReplay(
     video_link="",
     no_bomb=False,
     miss_count=None,
+    created_timestamp: typing.Optional[datetime.datetime] = None,
     imported_username: typing.Optional[str] = None,
 ):
     """Create a replay according to a file, with sensible defaults."""
@@ -75,5 +77,6 @@ def CreateAsPublishedReplay(
         replay_info=replay_info,
         no_bomb=no_bomb,
         miss_count=miss_count,
+        created_timestamp=created_timestamp,
         imported_username=imported_username,
     )


### PR DESCRIPTION
In case of ties, which happen frequently in counterstopped games, rank replays based on upload date. If that doesnt fix the tie (because 4 players counterstop on day 1, thanks zun), sort by ID as a desperate last resort to make rankings deterministic.