### PR TITLE
Rework leaderboard

### DIFF
--- a/project/thscoreboard/replays/templates/replays/game_scoreboard.html
+++ b/project/thscoreboard/replays/templates/replays/game_scoreboard.html
@@ -4,7 +4,7 @@
     <h2><a href="/replays/{{game.game_id}}">{{ game.GetFullName }}</a></h2>
 
     {% for filter_name, filter_values in filters.items %}
-        <div class="{% if filter_values|length >= 8 %}checkbox-list-4rows{% else %}checkbox-list{% endif %}">
+        <div class=button-container>
             {% for filter_value in filter_values %}
                 <label><button
                     class="button"

--- a/project/thscoreboard/replays/templates/replays/game_scoreboard.html
+++ b/project/thscoreboard/replays/templates/replays/game_scoreboard.html
@@ -5,6 +5,12 @@
 
     {% for filter_name, filter_values in filters.items %}
         <div class=button-container>
+            <label><button
+                class="button pressed"
+                filterType="{{filter_name}}"
+                value="All"
+                onclick="onClick(this)"
+            >All</label>
             {% for filter_value in filter_values %}
                 <label><button
                     class="button"

--- a/project/thscoreboard/replays/templates/replays/game_scoreboard.html
+++ b/project/thscoreboard/replays/templates/replays/game_scoreboard.html
@@ -6,8 +6,8 @@
     {% for filter_name, filter_values in filters.items %}
         <div class="{% if filter_values|length >= 8 %}checkbox-list-4rows{% else %}checkbox-list{% endif %}">
             {% for filter_value in filter_values %}
-                <label><input
-                    type="checkbox"
+                <label><button
+                    class="button"
                     filterType="{{filter_name}}"
                     value="{{filter_value}}"
                     onclick="onClick(this)"

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -3,6 +3,7 @@
 from django.views.decorators import http as http_decorators
 from django.shortcuts import get_object_or_404, render
 from django.db.models import Manager
+from django.core.handlers.wsgi import WSGIRequest
 
 from replays import models
 from replays import game_ids
@@ -12,14 +13,17 @@ from replays.views.replay_table_helpers import stream_json_bytes_to_http_reponse
 
 
 @http_decorators.require_safe
-def game_scoreboard_json(request, game_id: str):
+def game_scoreboard_json(request: WSGIRequest, game_id: str):
     replays = _get_all_replay_for_game(game_id)
     replay_jsons = convert_replays_to_json_bytes(replays)
     return stream_json_bytes_to_http_reponse(replay_jsons)
 
 
 @http_decorators.require_safe
-def game_scoreboard(request, game_id: str):
+def game_scoreboard(
+    request: WSGIRequest,
+    game_id: str,
+):
     game: Game = get_object_or_404(Game, game_id=game_id)
     filter_options = _get_filter_options(game)
     show_route = game_id in [
@@ -70,7 +74,11 @@ def _get_filter_options_th08(game: Game) -> dict[str, list[str]]:
     all_shots = [shot.GetName() for shot in Shot.objects.filter(game=game.game_id)]
     all_difficulties = [game.GetDifficultyName(d) for d in range(game.num_difficulties)]
     all_routes = [route.GetName() for route in Route.objects.filter(game=game.game_id)]
-    return {"Difficulty": all_difficulties, "Shot": all_shots, "Route": all_routes}
+    return {
+        "Difficulty": all_difficulties,
+        "Shot": all_shots,
+        "Route": all_routes,
+    }
 
 
 def _get_filter_options_th13(game: Game) -> dict[str, list[str]]:

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -8,6 +8,7 @@ var activeFilters = {};
 var allReplays = [];
 var tableResetCounter = 0;
 
+initializeFilters();
 requestAndInitializeReplays();
 
 async function requestAndInitializeReplays() {
@@ -53,6 +54,14 @@ async function requestAndInitializeReplays() {
   } catch (error) {}
 }
 
+function initializeFilters() {
+  const allButtons = document.querySelectorAll('button[filtertype]')
+  for (const button of allButtons) {
+    const filterType = button.getAttribute('filtertype');
+    activeFilters[filterType] = 'All';
+  }
+}
+
 function onClick(elm) {
   const filterType = elm.getAttribute('filterType');
   const value = elm.getAttribute('value');
@@ -70,30 +79,27 @@ function updateButtons(activeFilters) {
     const filterType = button.getAttribute('filtertype');
     const value = button.value;
     if (activeFilters[filterType] === value) {
-      button.className = "button pressed"
+      button.className = "button pressed";
     }
     else {
-      button.className = "button"
+      button.className = "button";
     }
   }
 }
 
 function updateFilters(filters, filterType, value) {
-  if (filters[filterType] === value) {
-    delete filters[filterType];
-  }
-  else {
-    filters[filterType] = value;
-  }
+  filters[filterType] = value;
   return filters;
 }
 
 function filterReplays(filters, replays) {
   let filteredReplays = [...replays];
   for (const [filterType, allowedValues] of Object.entries(filters)) {
-    filteredReplays = filteredReplays.filter((replay) => {
-      return replay[filterType] === allowedValues;
-    });
+    if (allowedValues !== "All") {
+      filteredReplays = filteredReplays.filter((replay) => {
+        return replay[filterType] === allowedValues;
+      });
+    }
   };
   return filteredReplays;
 }

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -27,7 +27,7 @@ async function requestAndInitializeReplays() {
     const reader = response.body.getReader();
     const decoder = new TextDecoder('utf-8');
     let buffer = '';
-  
+
     while (true) {
       const { done, value } = await reader.read();
       if (done) {
@@ -64,18 +64,11 @@ function onClick(elm) {
 }
 
 function updateFilters(filters, filterType, value) {
-  if (filters[filterType] === undefined) {
-    filters[filterType] = [];
-  }
-  const indexOfValue = filters[filterType].indexOf(value);
-  if (indexOfValue === -1) {
-    filters[filterType].push(value);
+  if (filters[filterType] === value) {
+    delete filters[filterType];
   }
   else {
-    filters[filterType].splice(indexOfValue, 1);
-    if (filters[filterType].length === 0) {
-      delete filters[filterType];
-    }
+    filters[filterType] = value;
   }
   return filters;
 }

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.js
@@ -58,9 +58,24 @@ function onClick(elm) {
   const value = elm.getAttribute('value');
 
   activeFilters = updateFilters(activeFilters, filterType, value);
+  updateButtons(activeFilters);
   const filteredReplays = filterReplays(activeFilters, allReplays);
   clearTableHtml();
   addReplaysToTable(filteredReplays);
+}
+
+function updateButtons(activeFilters) {
+  const allButtons = document.querySelectorAll('button[filtertype]')
+  for (const button of allButtons) {
+    const filterType = button.getAttribute('filtertype');
+    const value = button.value;
+    if (activeFilters[filterType] === value) {
+      button.className = "button pressed"
+    }
+    else {
+      button.className = "button"
+    }
+  }
 }
 
 function updateFilters(filters, filterType, value) {
@@ -77,7 +92,7 @@ function filterReplays(filters, replays) {
   let filteredReplays = [...replays];
   for (const [filterType, allowedValues] of Object.entries(filters)) {
     filteredReplays = filteredReplays.filter((replay) => {
-      return allowedValues.includes(replay[filterType]);
+      return replay[filterType] === allowedValues;
     });
   };
   return filteredReplays;

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
@@ -27,16 +27,27 @@ describe('updateFilters', () => {
 });
 
 describe('filterReplays', () => {
-    test('filters replays', () => {
+    test('filters replays with incorrect properties', () => {
         const filters = {"Difficulty": "Hard", "Shot": "Reimu"};
         const replays = [
             {"Score": 1000, "Difficulty": "Hard", "Shot": "Reimu", "Season": "Autumn"},
             {"Score": 2000, "Difficulty": "Hard", "Shot": "Reimu", "Season": "Autumn"},
             {"Score": 3000, "Difficulty": "Hard", "Shot": "Marisa", "Season": "Autumn"},
-            {"Score": 4000, "Difficulty": "Extra", "Shot": "Marisa", "Season": "Autumn"},
+            {"Score": 4000, "Difficulty": "Lunatic", "Shot": "Marisa", "Season": "Autumn"},
         ]
         const filteredReplays = filterReplays(filters, replays);
         const expectedFilteredReplays = [replays[0], replays[1]];
+        expect(filteredReplays).toEqual(expect.arrayContaining(expectedFilteredReplays));
+    });
+
+    test('filters replays with missing properties', () => {
+        const filters = {"Route": "Final A"};
+        const replays = [
+            {"Score": 1000, "Difficulty": "Hard", "Shot": "Reimu", "Route": "Final A"},
+            {"Score": 2000, "Difficulty": "Extra", "Shot": "Marisa", "Route": ""},
+        ]
+        const filteredReplays = filterReplays(filters, replays);
+        const expectedFilteredReplays = [replays[0]];
         expect(filteredReplays).toEqual(expect.arrayContaining(expectedFilteredReplays));
     });
 });

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
@@ -45,6 +45,7 @@ describe('filterReplays', () => {
         const replays = [
             {"Score": 1000, "Difficulty": "Hard", "Shot": "Reimu", "Route": "Final A"},
             {"Score": 2000, "Difficulty": "Extra", "Shot": "Marisa", "Route": ""},
+            {"Score": 3000, "Difficulty": "Extra", "Shot": "Marisa"},
         ]
         const filteredReplays = filterReplays(filters, replays);
         const expectedFilteredReplays = [replays[0]];

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
@@ -6,26 +6,21 @@ describe('updateFilters', () => {
     test('Adds filters', () => {
         let filters = {};
         filters = updateFilters(filters, "Difficulty", "Hard");
-        expect(filters).toEqual({"Difficulty": ["Hard"]});
+        expect(filters).toEqual({"Difficulty": "Hard"});
         filters = updateFilters(filters, "Shot", "Sakuya B");
-        expect(filters).toEqual({"Difficulty": ["Hard"], "Shot": ["Sakuya B"]});
+        expect(filters).toEqual({"Difficulty": "Hard", "Shot": "Sakuya B"});
+    });
+
+    test('Replaces active filters', () => {
+        let filters = {"Difficulty": "Hard", "Shot": "Sakuya B"};
         filters = updateFilters(filters, "Shot", "Reimu A");
-        expect(filters).toEqual({"Difficulty": ["Hard"], "Shot": ["Sakuya B", "Reimu A"]});
+        expect(filters).toEqual({"Difficulty": "Hard", "Shot": "Reimu A"});
     });
-    
+
     test('Removes filters', () => {
-        let filters = {"Difficulty": ["Hard", "Extra"], "Shot": ["Sakuya B", "Reimu A"]};
-        filters = updateFilters(filters, "Shot", "Sakuya B");
-        expect(filters).toEqual({"Difficulty": ["Hard", "Extra"], "Shot": ["Reimu A"]});
-        filters = updateFilters(filters, "Difficulty", "Extra");
-        expect(filters).toEqual({"Difficulty": ["Hard"], "Shot": ["Reimu A"]});
-    });
-    
-    test('Deletes filter type if empty', () => {
-        let filters = {"Difficulty": ["Hard"], "Shot": ["Sakuya B", "Reimu A"]};
+        let filters = {"Difficulty": "Hard", "Shot": "Reimu A"};
         filters = updateFilters(filters, "Difficulty", "Hard");
-        expect(filters).toEqual({"Shot": ["Sakuya B", "Reimu A"]});
-        filters = updateFilters(filters, "Shot", "Sakuya B");
+        expect(filters).toEqual({"Shot": "Reimu A"});
         filters = updateFilters(filters, "Shot", "Reimu A");
         expect(filters).toEqual({});
     });
@@ -33,13 +28,12 @@ describe('updateFilters', () => {
 
 describe('filterReplays', () => {
     test('filters replays', () => {
-        const filters = {"Difficulty": ["Hard"], "Shot": ["Cirno", "Reimu"]};
+        const filters = {"Difficulty": "Hard", "Shot": "Reimu"};
         const replays = [
-            {"Score": 1000, "Difficulty": "Hard", "Shot": "Cirno", "Season": "Autumn"},
+            {"Score": 1000, "Difficulty": "Hard", "Shot": "Reimu", "Season": "Autumn"},
             {"Score": 2000, "Difficulty": "Hard", "Shot": "Reimu", "Season": "Autumn"},
-            {"Score": 3000, "Difficulty": "Easy", "Shot": "Cirno", "Season": "Autumn"},
-            {"Score": 4000, "Difficulty": "Hard", "Shot": "Marisa", "Season": "Autumn"},
-            {"Score": 5000, "Difficulty": "Extra", "Shot": "Marisa", "Season": "Autumn"},
+            {"Score": 3000, "Difficulty": "Hard", "Shot": "Marisa", "Season": "Autumn"},
+            {"Score": 4000, "Difficulty": "Extra", "Shot": "Marisa", "Season": "Autumn"},
         ]
         const filteredReplays = filterReplays(filters, replays);
         const expectedFilteredReplays = [replays[0], replays[1]];
@@ -61,7 +55,7 @@ function setupTestDom() {
       </body>
     </html>
   `);
-  
+
   global.window = dom.window;
   global.document = dom.window.document;
 }

--- a/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
+++ b/project/thscoreboard/shared_content/static/js/replays/replayTable.test.js
@@ -16,14 +16,6 @@ describe('updateFilters', () => {
         filters = updateFilters(filters, "Shot", "Reimu A");
         expect(filters).toEqual({"Difficulty": "Hard", "Shot": "Reimu A"});
     });
-
-    test('Removes filters', () => {
-        let filters = {"Difficulty": "Hard", "Shot": "Reimu A"};
-        filters = updateFilters(filters, "Difficulty", "Hard");
-        expect(filters).toEqual({"Shot": "Reimu A"});
-        filters = updateFilters(filters, "Shot", "Reimu A");
-        expect(filters).toEqual({});
-    });
 });
 
 describe('filterReplays', () => {

--- a/project/thscoreboard/shared_content/static/style.sass
+++ b/project/thscoreboard/shared_content/static/style.sass
@@ -304,32 +304,11 @@ input
     text-decoration: none
     color: inherit
 
-.checkbox-list-4rows
-    display: inline-grid
-    grid-template-rows: repeat(4, minmax(0, 1fr))
-    grid-auto-flow: column
-    margin-right: 50px
-    margin-bottom: 20px
-    line-height: 1.15
-    
-.checkbox-list-4rows label
-    margin-right: 20px
-
-.checkbox-list
-    display: inline-block
-    vertical-align: top
-    margin-right: 50px
-    margin-bottom: 20px
-    line-height: 1.15
-
-.checkbox-list label
-    display: block
-
 .button-container
     display: block
     margin-bottom: 10px
 
-.button 
+.button
   flex: content
   border: none
   padding: 10px 15px
@@ -341,4 +320,3 @@ input
 
 .button.pressed
   background-color: var(--pressed-button-color)
-  


### PR DESCRIPTION
![image](https://github.com/n-rook/thscoreboard/assets/44336657/b1a9659e-515f-47b5-ab5f-392ff3108881)

- Replaces checkboxes with nice big buttons. Much prettier and easier to press!
- Only allow 0-1 option in each category to be selected (eg. disallow selecting both Reimu + Marisa at once)
  - This removes a feature, but saves you a click when you want to switch to just one category to another
  - It's also preparation for having simple url query strings for each category, like replays/th08?shot=youmu&route=final%20b