### PR TITLE
Add replay-specific meta tags.

### DIFF
--- a/project/thscoreboard/replays/templates/replays/replay_details.html
+++ b/project/thscoreboard/replays/templates/replays/replay_details.html
@@ -11,6 +11,8 @@
 {% endif %}
 {% endblock %}
 
+{% block embed_title %}{{ game_name }}{% if route_name %}, {{ route_name }}{% endif %} – {{ difficulty_name }} ({{ shot_name }}) – {{ replay.score|intcomma }}{% endblock %}
+{% block embed_description %}{% if replay.timestamp %}{% with replay_timestamp=replay.GetFormattedTimestampDate %}{% blocktranslate %}Played by {{ player_name }} on {{ replay_timestamp }}{% endblocktranslate %}{% endwith %}{% else %}{% blocktranslate %}Played by {{ player_name }}{% endblocktranslate %}{% endif %}{% endblock %}
 {% block content %}
 <script src="/static/js/replays/replay_details.js"></script>
 


### PR DESCRIPTION
This way, links to replays will look better in places like Discord.

The templating unfortunately does have to be a horrible never-ending line, because whitespace inside meta tags modifies how it is rendered.
<img width="432" alt="Screenshot 2023-08-05 at 3 39 02 PM" src="https://github.com/n-rook/thscoreboard/assets/9295955/cf5c24c3-624a-4e84-bc74-0915dfc02a48">
