### PR TITLE
Only rank full game replays

### DIFF
--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -204,7 +204,7 @@ class ReplayQuerySet(QuerySet):
         return self.annotate(
             rank=Case(
                 When(
-                    category=Category.STANDARD,
+                    Q(category=Category.STANDARD) & Q(replay_type=ReplayType.FULL_GAME),
                     then=Window(
                         expression=RowNumber(),
                         order_by=[

--- a/project/thscoreboard/replays/test_models.py
+++ b/project/thscoreboard/replays/test_models.py
@@ -186,6 +186,16 @@ class ReplayTest(test_case.ReplayTestCase):
         self.assertEquals(replays[1].rank, 2)
         self.assertEquals(replays[2].rank, 3)
 
+    def testStagePracticeReplaysAreUnranked(self) -> None:
+        test_replays.CreateAsPublishedReplay(
+            filename="th6_extra",
+            user=self.author,
+            replay_type=models.ReplayType.STAGE_PRACTICE,
+        )
+
+        replay = models.Replay.objects.annotate_with_rank().first()
+        self.assertEquals(replay.rank, -1)
+
     def testGetFormattedTimestampDate_NoDate(self):
         th05_mima = models.Shot.objects.get(
             game_id=game_ids.GameIDs.TH05, shot_id="Mima"

--- a/project/thscoreboard/replays/testing/test_replays.py
+++ b/project/thscoreboard/replays/testing/test_replays.py
@@ -50,6 +50,7 @@ def CreateAsPublishedReplay(
     miss_count=None,
     created_timestamp: typing.Optional[datetime.datetime] = None,
     imported_username: typing.Optional[str] = None,
+    replay_type: typing.Optional[models.ReplayType] = None,
 ):
     """Create a replay according to a file, with sensible defaults."""
 
@@ -58,6 +59,8 @@ def CreateAsPublishedReplay(
     temp_replay.save()
 
     replay_info = replay_parsing.Parse(replay_file_contents)
+    if replay_type is not None:
+        replay_info.replay_type = replay_type
 
     if difficulty is None:
         difficulty = replay_info.difficulty


### PR DESCRIPTION
Currently, spell practice, stage practice, and PVP replays are ranked and given medals. Instead, only full game runs should be ranked.

Fixes #387