### PR TITLE
Seamlessly delete replays that duplicate a new replay but are owned by an inactive user.

### DIFF
--- a/project/thscoreboard/replays/constant_helpers.py
+++ b/project/thscoreboard/replays/constant_helpers.py
@@ -44,15 +44,17 @@ def GetModelInstancesForReplay(
     return ReplayConstantModels(game=shot.game, shot=shot, route=route)
 
 
-def GetReplayFileWithSameHash(file, include_ghosts = False) -> Optional[models.ReplayFile]:
+def GetReplayFileWithSameHash(
+    file, include_ghosts=False
+) -> Optional[models.ReplayFile]:
     """Return a replay file with the same hash is this one, if present.
-    
+
     Args:
         file: The file data (bytes or memoryview).
         include_ghosts: If true, return "ghosts": replay files associated with
             deleted accounts (that is, accounts with is_active set to False).
             Ghosts are ignored for most purposes.
-    
+
     Returns:
         The matching replay file, or None.
     """
@@ -61,6 +63,7 @@ def GetReplayFileWithSameHash(file, include_ghosts = False) -> Optional[models.R
     if not include_ghosts:
         q = q.filter(replay__user__is_active=True)
     return q.first()
+
 
 def CalculateReplayFileHash(file):
     return hashlib.sha256(file).digest()

--- a/project/thscoreboard/replays/create_replay.py
+++ b/project/thscoreboard/replays/create_replay.py
@@ -5,13 +5,53 @@ not with web entities like views or forms.
 """
 
 import datetime
+import logging
 from typing import Optional
-from django.db import transaction
 
+from django.db import transaction
+from django.db import utils
+
+from shared_content import db_errors
 from replays import constant_helpers
 from replays import game_ids
 from replays import models
 from replays import replay_parsing
+
+
+def _SaveNewReplayWithFile(r: models.Replay, rf: models.ReplayFile):
+    r.save()
+    try:
+        # If there is an error in a transaction, that transaction is rolled
+        # back. As such, we execute rf.save() in a nested transaction— that
+        # way, only this tiny transaction is rolled back, and the outer transaction
+        # (if any) can continue as expected. (Of course, if the error can't be
+        # handled here, it will be reraised, so the outer transaction will be
+        # rolled back too.)
+        with transaction.atomic():
+            rf.save()
+    except utils.IntegrityError as e:
+        if (
+            not db_errors.IsUniqueError(e)
+            or not db_errors.GetUniqueConstraintCause(e) == "unique_hash"
+        ):
+            raise
+
+        at_least_one_ghost = False
+        for ghost in models.Replay.objects.ghosts_of(rf.replay_hash):
+            logging.info(
+                "Deleting ghost replay (with ID %d; owned by %s)",
+                ghost.id,
+                ghost.user.username,
+            )
+            ghost.delete()
+            at_least_one_ghost = True
+
+        if at_least_one_ghost:
+            rf.save()
+        else:
+            # As there were no ghosts, the save attempt was blocked by
+            # a real duplicate.
+            raise
 
 
 @transaction.atomic
@@ -91,8 +131,7 @@ def PublishNewReplay(
         ),
     )
 
-    replay_instance.save()
-    replay_file_instance.save()
+    _SaveNewReplayWithFile(replay_instance, replay_file_instance)
     temp_replay_instance.delete()
 
     for s in replay_info.stages:

--- a/project/thscoreboard/replays/create_replay.py
+++ b/project/thscoreboard/replays/create_replay.py
@@ -17,8 +17,7 @@ from replays import models
 from replays import replay_parsing
 
 
-def _SaveNewReplayWithFile(r: models.Replay, rf: models.ReplayFile):
-    r.save()
+def _CreateNewReplayFile(rf: models.ReplayFile):
     try:
         # If there is an error in a transaction, that transaction is rolled
         # back. As such, we execute rf.save() in a nested transaction— that
@@ -127,7 +126,8 @@ def PublishNewReplay(
         ),
     )
 
-    _SaveNewReplayWithFile(replay_instance, replay_file_instance)
+    replay_instance.save()
+    _CreateNewReplayFile(replay_file_instance)
     temp_replay_instance.delete()
 
     for s in replay_info.stages:

--- a/project/thscoreboard/replays/create_replay.py
+++ b/project/thscoreboard/replays/create_replay.py
@@ -11,7 +11,6 @@ from typing import Optional
 from django.db import transaction
 from django.db import utils
 
-from shared_content import db_errors
 from replays import constant_helpers
 from replays import game_ids
 from replays import models
@@ -30,10 +29,7 @@ def _SaveNewReplayWithFile(r: models.Replay, rf: models.ReplayFile):
         with transaction.atomic():
             rf.save()
     except utils.IntegrityError as e:
-        if (
-            not db_errors.IsUniqueError(e)
-            or not db_errors.GetUniqueConstraintCause(e) == "unique_hash"
-        ):
+        if not models.ReplayFile.IsUniqueHashCollisionError(e):
             raise
 
         at_least_one_ghost = False

--- a/project/thscoreboard/replays/create_replay.py
+++ b/project/thscoreboard/replays/create_replay.py
@@ -41,7 +41,7 @@ def _SaveNewReplayWithFile(r: models.Replay, rf: models.ReplayFile):
             logging.info(
                 "Deleting ghost replay (with ID %d; owned by %s)",
                 ghost.id,
-                ghost.user.username,
+                ghost.user,
             )
             ghost.delete()
             at_least_one_ghost = True

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -225,6 +225,20 @@ class ReplayQuerySet(QuerySet):
             )
         )
 
+    def ghosts_of(self, replay_hash: bytes) -> "ReplayQuerySet":
+        """Matches ghosts of a given replay file.
+
+        A "ghost" of a replay is an existing replay with an identical ReplayFile
+        assigned to an inactive user account. Such replays exist in the database so
+        they can be brought back to life if the user account is revived. However, to
+        users they do not exist, so it is inappropriate to prevent users from uploading
+        duplicates of ghosts.
+        """
+        return self.filter(
+            replayfile__replay_hash=replay_hash,
+            user__is_active=False,
+        )
+
 
 class Replay(models.Model):
     """Represents a score recorded on the scoreboard."""

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -6,6 +6,7 @@ import datetime
 from typing import Optional
 
 from django.db import models
+from django.db import utils
 from django.utils import formats
 from django.utils import timezone
 from django.utils.translation import pgettext_lazy
@@ -15,6 +16,7 @@ from django.db.models.functions import RowNumber
 from replays import game_ids
 from replays import limits
 from replays import replay_parsing
+from shared_content import db_errors
 from shared_content import model_ttl
 from thscoreboard import settings
 
@@ -601,12 +603,25 @@ class ReplayStage(models.Model):
         self.th16_season_power = s.th16_season_power
 
 
+_REPLAY_FILE_UNIQUE_HASH_CONSTRAINT = "unique_hash"
+
+
 class ReplayFile(models.Model):
     """Represents a replay file for a given score."""
 
+    @classmethod
+    def IsUniqueHashCollisionError(cls, e: utils.IntegrityError):
+        return (
+            db_errors.IsUniqueError(e)
+            and db_errors.GetUniqueConstraintCause(e)
+            == _REPLAY_FILE_UNIQUE_HASH_CONSTRAINT
+        )
+
     class Meta:
         constraints = [
-            models.UniqueConstraint(fields=["replay_hash"], name="unique_hash")
+            models.UniqueConstraint(
+                fields=["replay_hash"], name=_REPLAY_FILE_UNIQUE_HASH_CONSTRAINT
+            )
         ]
 
     replay = models.OneToOneField("Replay", on_delete=models.CASCADE)

--- a/project/thscoreboard/replays/test_create_replay.py
+++ b/project/thscoreboard/replays/test_create_replay.py
@@ -284,6 +284,32 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
         with self.assertRaises(models.Replay.DoesNotExist):
             models.Replay.objects.get(score=67890)
 
+    def testReplayDuplicateFromRoyalFlare(self):
+        test_replays.CreateAsPublishedReplay("th6_extra", imported_username="someone")
+
+        replay_file_contents = test_replays.GetRaw("th6_extra")
+        temp_replay = models.TemporaryReplayFile(
+            user=self.user, replay=replay_file_contents
+        )
+        temp_replay.save()
+        replay_info = replay_parsing.Parse(replay_file_contents)
+
+        with self.assertRaises(utils.IntegrityError):
+            create_replay.PublishNewReplay(
+                user=self.user,
+                difficulty=3,
+                score=1234567,
+                category=models.Category.STANDARD,
+                comment="",
+                video_link="",
+                is_good=True,
+                is_clear=True,
+                no_bomb=False,
+                miss_count=None,
+                temp_replay_instance=temp_replay,
+                replay_info=replay_info,
+            )
+
     def testReplayDuplicates_DeletesGhosts(self):
         inactive_user = self.createUser("inactive")
 

--- a/project/thscoreboard/replays/test_create_replay.py
+++ b/project/thscoreboard/replays/test_create_replay.py
@@ -242,7 +242,7 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
         replay_1 = create_replay.PublishNewReplay(
             user=self.user,
             difficulty=3,
-            score=294127890,
+            score=12345,
             category=models.Category.STANDARD,
             comment="",
             video_link="",
@@ -265,7 +265,7 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
             create_replay.PublishNewReplay(
                 user=self.user,
                 difficulty=3,
-                score=294127890,
+                score=67890,
                 category=models.Category.STANDARD,
                 comment="",
                 video_link="",
@@ -281,3 +281,37 @@ class GameIDsComprehensiveTestCase(test_case.ReplayTestCase):
             constant_helpers.GetReplayFileWithSameHash(replay_file_contents).replay,
             replay_1,
         )
+        with self.assertRaises(models.Replay.DoesNotExist):
+            models.Replay.objects.get(score=67890)
+
+    def testReplayDuplicates_DeletesGhosts(self):
+        inactive_user = self.createUser("inactive")
+
+        ghost = test_replays.CreateAsPublishedReplay("th6_extra", user=inactive_user)
+        inactive_user.MarkForDeletion()
+
+        replay_file_contents = test_replays.GetRaw("th6_extra")
+        temp_replay = models.TemporaryReplayFile(
+            user=self.user, replay=replay_file_contents
+        )
+        temp_replay.save()
+        replay_info = replay_parsing.Parse(replay_file_contents)
+
+        create_replay.PublishNewReplay(
+            user=self.user,
+            difficulty=3,
+            score=1234567,
+            category=models.Category.STANDARD,
+            comment="",
+            video_link="",
+            is_good=True,
+            is_clear=True,
+            no_bomb=False,
+            miss_count=None,
+            temp_replay_instance=temp_replay,
+            replay_info=replay_info,
+        )
+        # No duplicate error.
+
+        with self.assertRaises(models.Replay.DoesNotExist):
+            models.Replay.objects.get(id=ghost.pk)

--- a/project/thscoreboard/replays/test_models.py
+++ b/project/thscoreboard/replays/test_models.py
@@ -280,7 +280,7 @@ class ReplayFileTest(test_case.ReplayTestCase):
         self.user = self.createUser("somebody")
 
     def testIsUniqueHashCollisionErrorWorks(self):
-        r = test_replays.CreateAsPublishedReplay(
+        test_replays.CreateAsPublishedReplay(
             filename="th7_lunatic",
             user=self.user,
         )

--- a/project/thscoreboard/shared_content/db_errors.py
+++ b/project/thscoreboard/shared_content/db_errors.py
@@ -1,0 +1,24 @@
+from django.db import utils
+from psycopg2 import errors
+
+
+def IsUniqueError(e: utils.IntegrityError) -> bool:
+    """Return whether the error was caused by a unique constraint."""
+
+    return isinstance(e.__cause__, errors.UniqueViolation)
+
+
+def GetUniqueConstraintCause(e: utils.IntegrityError) -> str:
+    """Returns the unique constraint that caused an error."""
+
+    if not IsUniqueError(e):
+        raise ValueError("The exception passed was not a unique constraint error.")
+
+    unique_violation: errors.UniqueViolation = e.__cause__
+    constraint_name = unique_violation.diag.constraint_name
+    if not constraint_name:
+        raise ValueError(
+            f"Unexpected error: Exception {unique_violation} had no constraint_name"
+        )
+
+    return constraint_name

--- a/project/thscoreboard/shared_content/test_db_errors.py
+++ b/project/thscoreboard/shared_content/test_db_errors.py
@@ -1,0 +1,40 @@
+from django.db import utils
+
+from shared_content import db_errors
+
+from replays import models
+from replays.testing import test_case
+from replays.testing import test_replays
+
+
+class DbErrorsTest(test_case.ReplayTestCase):
+    def testRecognizesUniqueViolation(self):
+        game = models.Game(game_id="th999", has_replays=True, num_difficulties=5)
+        game.save()
+
+        shot = models.Shot(game=game, shot_id="foo")
+        shot.save()
+
+        dupe_shot = models.Shot(game=game, shot_id="foo")
+
+        try:
+            dupe_shot.save()
+        except utils.IntegrityError as e:
+            self.assertTrue(db_errors.IsUniqueError(e))
+            self.assertEqual(
+                db_errors.GetUniqueConstraintCause(e), "unique_shot_per_game"
+            )
+        else:
+            self.fail("Unexpected failure to raise an error")
+
+    def testDoesNotThinkOtherViolationIsUnique(self):
+        user = self.createUser("user")
+        replay = test_replays.CreateAsPublishedReplay("th6_extra", user=user)
+        replay.difficulty = -5
+
+        try:
+            replay.save()
+        except utils.IntegrityError as e:
+            self.assertFalse(db_errors.IsUniqueError(e))
+        else:
+            self.fail("Unexpected failure to raise an error")


### PR DESCRIPTION
Fixes #462