### PR TITLE
Update ksy property name to match with generated files

### DIFF
--- a/ref/threp-ksy/th11.ksy
+++ b/ref/threp-ksy/th11.ksy
@@ -37,7 +37,7 @@ types:
         size: 8
   stage:
     seq:
-      - id: stage
+      - id: stage_num
         type: u2
       - id: seed
         type: u2

--- a/ref/threp-ksy/th12.ksy
+++ b/ref/threp-ksy/th12.ksy
@@ -39,7 +39,7 @@ types:
         type: u4
   stage:
     seq:
-      - id: stage
+      - id: stage_num
         type: u2
       - id: seed
         type: u2


### PR DESCRIPTION
Probably not a very useful commit but it helps those who want to compare the `ksy` files with the generated files on thscoreboard ~~because the user generated files may not be the same as your generated files~~.