### PR TITLE
Reorganize game list on left navigation bar.

### DIFF
--- a/project/thscoreboard/replays/get_all_games.py
+++ b/project/thscoreboard/replays/get_all_games.py
@@ -1,6 +1,7 @@
+import collections
 from typing import Iterable
-from replays import game_ids
 
+from replays import game_ids
 from replays import models
 
 
@@ -10,6 +11,29 @@ PC98_GAME_IDS = [
     game_ids.GameIDs.TH03,
     game_ids.GameIDs.TH04,
     game_ids.GameIDs.TH05,
+]
+
+CLASSIC_GAME_IDS = [
+    game_ids.GameIDs.TH06,
+    game_ids.GameIDs.TH07,
+    game_ids.GameIDs.TH08,
+    game_ids.GameIDs.TH09,
+]
+
+DIVINE_CYCLE_GAME_IDS = [
+    game_ids.GameIDs.TH10,
+    game_ids.GameIDs.TH11,
+    game_ids.GameIDs.TH12,
+    game_ids.GameIDs.TH13,
+    game_ids.GameIDs.TH128,
+]
+
+NEW_GAME_IDS = [
+    game_ids.GameIDs.TH14,
+    game_ids.GameIDs.TH15,
+    game_ids.GameIDs.TH16,
+    game_ids.GameIDs.TH17,
+    game_ids.GameIDs.TH18,
 ]
 
 
@@ -24,6 +48,23 @@ def get_windows_games() -> list[models.Game]:
 
 
 def get_all_games_by_category() -> dict[str, list[models.Game]]:
-    """Returns a list of all Touhou games by category (pc-98, windows, etc.), in a
-    reasonable order."""
-    return {"PC-98": get_pc98_games(), "Windows": get_windows_games()}
+    """Returns all Touhou games, organized by category.
+
+    The categories are fairly arbitrary, and are not intended to be used for
+    more than visually categorizing and separating games.
+
+    Returns:
+        A dict from "category IDs" (strings) to lists of Games. The dictionary
+        is ordered in a reasonable order for the games to be listed.
+    """
+    all_games_by_id = {g.game_id: g for g in models.Game.objects.all()}
+
+    def GamesIn(id_list):
+        return [all_games_by_id[game_id] for game_id in id_list]
+
+    return {
+        "PC-98": GamesIn(PC98_GAME_IDS),
+        "Classic": GamesIn(CLASSIC_GAME_IDS),
+        "Divine": GamesIn(DIVINE_CYCLE_GAME_IDS),
+        "New": GamesIn(NEW_GAME_IDS),
+    }

--- a/project/thscoreboard/replays/get_all_games.py
+++ b/project/thscoreboard/replays/get_all_games.py
@@ -1,4 +1,3 @@
-import collections
 from typing import Iterable
 
 from replays import game_ids

--- a/project/thscoreboard/replays/test_get_all_games.py
+++ b/project/thscoreboard/replays/test_get_all_games.py
@@ -1,13 +1,8 @@
 import itertools
 
-from replays import game_ids
 from replays import models
 from replays import get_all_games
-from replays import create_replay
-from replays import replay_parsing
-from replays import constant_helpers
 from replays.testing import test_case
-from replays.testing import test_replays
 
 
 class ReplayTest(test_case.ReplayTestCase):

--- a/project/thscoreboard/replays/test_get_all_games.py
+++ b/project/thscoreboard/replays/test_get_all_games.py
@@ -1,0 +1,26 @@
+import itertools
+
+from replays import game_ids
+from replays import models
+from replays import get_all_games
+from replays import create_replay
+from replays import replay_parsing
+from replays import constant_helpers
+from replays.testing import test_case
+from replays.testing import test_replays
+
+
+class ReplayTest(test_case.ReplayTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def testGetByCategoryReturnsAllGamesExactlyOnce(self):
+        all_games = models.Game.objects.all()
+        all_games_by_category = get_all_games.get_all_games_by_category()
+        games_from_categories = itertools.chain.from_iterable(
+            all_games_by_category.values()
+        )
+        self.assertCountEqual(
+            (g.game_id for g in all_games),
+            (g.game_id for g in games_from_categories),
+        )

--- a/project/thscoreboard/shared_content/static/style.sass
+++ b/project/thscoreboard/shared_content/static/style.sass
@@ -113,6 +113,11 @@ body
         li
             margin: 4px 0
             list-style-type: none
+    
+    hr
+        border-style: solid
+        border-color: var(--horizontal-rule-color)
+        border-width: 1px
 
     .game-list
         padding-left: 5px

--- a/project/thscoreboard/shared_content/static/themes.sass
+++ b/project/thscoreboard/shared_content/static/themes.sass
@@ -53,6 +53,9 @@
 
     --horizontal-list-bullet-color: #71196f
 
+    // Color used for <hr>.
+    --horizontal-rule-color: #bbbbbb
+
     // Colors used for inline icons.
     --lives-icon-color: #e2008b
     --bombs-icon-color: #1fcd00
@@ -92,6 +95,8 @@
     --hover-button-color: #500050
 
     --horizontal-list-bullet-color: #eeb7ed
+
+    --horizontal-rule-color: #707070
 
     --lives-icon-color: #ff6ec7
     --bombs-icon-color: #39ff14

--- a/project/thscoreboard/thscoreboard/templates/base.html
+++ b/project/thscoreboard/thscoreboard/templates/base.html
@@ -61,10 +61,13 @@
         </div>
         <div class="content-and-sidebar">
             <nav class="sidebar">
-                {% for game_category, games in all_games_by_category.items %}
                 <h1 class="highlight">
-                    {{game_category}}
+                    {% translate "Scoreboards" %}
                 </h1>
+                {% for game_category, games in all_games_by_category.items %}
+                {% if not forloop.first %}
+                <hr>
+                {% endif %}
                 <ul class="game-list">
                     {% for game in games %}
                     <li>


### PR DESCRIPTION
It's hard to read a list of 10+ games without being organized, so this splits the list up a bit.

The actual categorization is fairly arbitrary, which is why the categories aren't labeled on the frontend. Historically, the English community has divided the Windows games into "Classic", "Modern1" and "Modern2" categories, where "Modern1" starts with Mountain of Faith and "Modern2" includes more recent engine upgrades. However, there isn't an obvious place to start "Modern2", since the engine upgrades were added over multiple games. As such, I chose to use the plot; MoF-TD have a clear thematic throughline, whereas DDC is totally unrelated to TD and serves as a new beginning.

I thought about styling the horizontal rule, but I wound up preferring the default grey to any color I came up with.

This does not affect the ranking page.

<img width="265" alt="Screenshot 2023-10-06 at 1 47 58 PM" src="https://github.com/n-rook/thscoreboard/assets/9295955/09a62e50-c7e3-493e-acf8-7a0fa2751ba2">
