### PR TITLE
Make test_templates pass on Windows.

### DIFF
--- a/project/thscoreboard/thscoreboard/test_templates.py
+++ b/project/thscoreboard/thscoreboard/test_templates.py
@@ -25,7 +25,10 @@ def ListTemplateFiles() -> list[str]:
 
 
 def ListTemplates():
-    return [(filepath, filepath.read_text()) for filepath in ListTemplateFiles()]
+    return [
+        (filepath, filepath.read_text(encoding="utf-8"))
+        for filepath in ListTemplateFiles()
+    ]
 
 
 class TemplatesTestCase(test.TestCase):


### PR DESCRIPTION
Some (all, I think) of the template files are utf8 so Windows got confused.