### PR TITLE
Update repo to match new, Debian Bookworm state of the server.

### DIFF
--- a/.github/workflows/run_python_tests.yml
+++ b/.github/workflows/run_python_tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 LOCAL_NOTES
 .vscode
+.venv

--- a/README.md
+++ b/README.md
@@ -93,3 +93,27 @@ There isn't a hook yet to actually switch the language to Japanese.
 - set up constant tables
 - add tests
 - add front end translations for added string literals
+
+## The production environment
+
+The production server uses venv:
+
+https://docs.python.org/3/library/venv.html
+
+It was a fun surprise to see the version of pip installed by default in Debian
+Bookworm only supports venv by default!
+
+venv is essentially a way of isolating Python environments from each other, so
+that (for example) different servers can use different versions of the same
+module.
+
+The virtual environment is installed to .venv in each server directory (that is,
+for example, `/home/silentselene/silentselene-staging/.venv)`. To enter the
+venv, run  `. .venv/bin/activate`. Once you're in the venv, Python and related
+tools are referenced from the venv; for example, python is
+`/home/silentselene/silentselene-staging/.venv/bin/python`. Commands like
+`pip install` will install to the venv.
+
+Note that the venvs were created by running `python -m venv .venv` in these
+directories. As always, manage these as `silentselene`, not root, or else
+root will wind up owning files.

--- a/ref/server/systemd/silentselene-staging.service
+++ b/ref/server/systemd/silentselene-staging.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Silent Selene (staging)
+After=network.target
+After=postgresql.service
+
+[Service]
+Type=simple
+KillSignal=SIGINT
+Restart=always
+RestartSec=1
+User=silentselene
+WorkingDirectory=/home/silentselene/silentselene-staging/project/thscoreboard/
+ExecStart=uwsgi_python311 /home/silentselene/silentselene-staging/ref/server/uwsgi-staging.ini
+
+[Install]
+WantedBy=multi-user.target

--- a/ref/server/systemd/silentselene.service
+++ b/ref/server/systemd/silentselene.service
@@ -10,7 +10,7 @@ Restart=always
 RestartSec=1
 User=silentselene
 WorkingDirectory=/home/silentselene/silentselene/project/thscoreboard/
-ExecStart=uwsgi /home/silentselene/silentselene/ref/server/uwsgi.ini
+ExecStart=uwsgi_python311 /home/silentselene/silentselene/ref/server/uwsgi.ini
 
 [Install]
 WantedBy=multi-user.target

--- a/ref/server/uwsgi-staging.ini
+++ b/ref/server/uwsgi-staging.ini
@@ -1,0 +1,7 @@
+[uwsgi]
+socket = localhost:8001
+chdir = /home/silentselene/silentselene-staging/project/thscoreboard
+virtualenv = /home/silentselene/silentselene-staging/.venv
+wsgi-file = thscoreboard/wsgi.py
+master = true
+logformat = [%(var.REMOTE_ADDR)] (%(msecs)ms) %(status) %(method) %(uri)

--- a/ref/server/uwsgi.ini
+++ b/ref/server/uwsgi.ini
@@ -1,6 +1,7 @@
 [uwsgi]
 socket = localhost:8000
 chdir = /home/silentselene/silentselene/project/thscoreboard
+virtualenv = /home/silentselene/silentselene/.venv
 wsgi-file = thscoreboard/wsgi.py
 master = true
 logformat = [%(var.REMOTE_ADDR)] (%(msecs)ms) %(status) %(method) %(uri)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 bcrypt==4.0.1
 django==4.2.4
+django-compressor==4.4
 django-sass-processor==1.2.2
 freezegun==1.2.2
 immutabledict==3.0.0
 kaitaistruct==0.10
 libsass==0.22.0
 postgres==4.0
+requests==2.31.0
 tsadecode==0.6
 whitenoise==6.5.0


### PR DESCRIPTION
There are a few different types of changes in this PR:

- The new version of pip supplied strongly prefers venv. As such, to get it working, I started using venv. As such, I document it here and update the uwsgi.ini files accordingly.
- uwsgi-staging was crafted outside of git, so I bring it in here.
- uwsgi is now installed through apt (though I'm not sure how it was installed before). As such, we now run a binary called uwsgi_python311 which is a version of uwsgi built to support Python 3.11. (I'm not sure exactly what the deal is with uwsgi's plugin architecture, but this works for now.)
- The new Debian supplies Python 3.11, so I started using it.
- A few Python libraries got accidentally left out of requirements.txt. requests is used by the Discord plugin that announces new versions. django-compressor is used by the `compilescss` admin command.

Normally I would put these in different PRs, but since this all constitutes one big update to bring over the changes I've already done on the prod server, I figured it was easiest to see it all as one big piece.