### PR TITLE
Create a test for the "create replay" view.

### DIFF
--- a/project/thscoreboard/replays/urls/replay_urls.py
+++ b/project/thscoreboard/replays/urls/replay_urls.py
@@ -12,7 +12,11 @@ urlpatterns = [
     path("", index.index, name="index"),
     path("index/json", index.index_json),
     path("upload", create_replay.upload_file, name="upload_file"),
-    path("publish/<int:temp_replay_id>", create_replay.publish_replay),
+    path(
+        "publish/<int:temp_replay_id>",
+        create_replay.publish_replay,
+        name="publish_replay",
+    ),
     path("publish/<str:game_id>", create_replay.publish_replay_no_file),
     path("user/<str:username>", user.user_page, name="user_page"),
     path("user/<str:username>/json", user.user_page_json),

--- a/project/thscoreboard/replays/views/test_create_replay.py
+++ b/project/thscoreboard/replays/views/test_create_replay.py
@@ -1,0 +1,59 @@
+from django import test as django_test
+from django import urls
+
+from replays import models
+from replays.views import create_replay
+from replays import replay_parsing
+from replays.testing import test_case
+from replays.testing import test_replays
+
+
+class CreateReplayTestCase(test_case.ReplayTestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = django_test.RequestFactory()
+        self.user = self.createUser("some-user")
+
+    def testOrdinaryReplay(self):
+        replay_file_contents = test_replays.GetRaw("th10_normal")
+        replay_info = replay_parsing.Parse(replay_file_contents)
+
+        temp_replay = models.TemporaryReplayFile(
+            user=self.user, replay=replay_file_contents
+        )
+        temp_replay.save()
+
+        request = self.factory.post(
+            urls.reverse("publish_replay", kwargs={"temp_replay_id": temp_replay.id}),
+            data={
+                "score": replay_info.score,
+                "category": models.Category.STANDARD,
+                "comment": "Hello, world!",
+                "is_good": True,
+                "is_clear": True,
+                "video_link": "",
+                "name": replay_info.name,
+                "uses_bombs": True,
+                "misses": 5,
+            },
+        )
+        request.user = self.user
+        response = create_replay.publish_replay(request, temp_replay.id)
+        self.assertEqual(response.status_code, 302)
+
+        target = urls.resolve(response.url)
+        replay = models.Replay.objects.get(id=target.captured_kwargs["replay_id"])
+
+        self.assertEqual(replay.shot.game.game_id, target.captured_kwargs["game_id"])
+        self.assertEqual(replay.score, replay_info.score)
+        self.assertEqual(replay.category, models.Category.STANDARD)
+        self.assertEqual(replay.comment, "Hello, world!")
+        self.assertTrue(replay.is_good)
+        self.assertTrue(replay.is_clear)
+        self.assertEqual(replay.video_link, "")
+        self.assertEqual(replay.name, replay_info.name)
+        self.assertFalse(replay.no_bomb)
+        self.assertEqual(replay.miss_count, 5)
+
+        with self.assertRaises(models.TemporaryReplayFile.DoesNotExist):
+            models.TemporaryReplayFile.objects.get(id=temp_replay.id)


### PR DESCRIPTION
This test is largely a proof-of-concept: I want to add a new view but was worried enough about it that I wanted a test for it. So, I figured I would add a test for an existing view first, to see how it worked.

In the past, we had a test like this and it was flaky enough that we got rid of it. However, this new test differs from the old one in that it uses RequestFactory:

https://docs.djangoproject.com/en/4.2/topics/testing/advanced/

My understanding is that this means that no actual HTTP requests are being issued; rather, we are constructing a fake request object directly in the test. This should avoid the source of flakiness.

I'm a bit ambivalent about this test; it's unfortunate that I have to directly pass in a dictionary that is supposed to correspond to the form on the page. I do think this test has value, mainly to warn us if we accidentally totally break this page, but I'm not about to start mandating similar tests for every new view. In terms of the test hierarchy, this is really just a giant unit test, where the unit being tested is the view.