### PR TITLE
Add a custom field type for Django enums.

### DIFF
--- a/project/thscoreboard/replays/forms.py
+++ b/project/thscoreboard/replays/forms.py
@@ -12,6 +12,7 @@ from replays import game_ids
 from replays import game_fields
 from replays import models
 from replays import limits
+from replays.lib import custom_fields
 
 difficulty_names = (
     ("0", "Easy"),
@@ -138,7 +139,7 @@ class PublishReplayForm(forms.Form):
             del self.fields["misses"]
 
     score = forms.IntegerField(min_value=0)
-    category = forms.ChoiceField(choices=models.Category.choices)
+    category = custom_fields.ChoicesEnumField(models.Category)
     comment = _create_comment_field()
     is_good = forms.BooleanField(initial=True, required=False)
     is_clear = forms.BooleanField(initial=True, required=False)
@@ -182,8 +183,8 @@ class PublishReplayWithoutFileForm(forms.Form):
     shot = ShotField()
     route = RouteField()
     score = forms.IntegerField(min_value=0)
-    category = forms.ChoiceField(choices=models.Category.choices)
-    replay_type = forms.ChoiceField(choices=models.ReplayType.choices)  # overridden
+    category = custom_fields.ChoicesEnumField(models.Category)
+    replay_type = custom_fields.ChoicesEnumField(models.ReplayType)  # overridden
     is_clear = forms.BooleanField(initial=True, required=False)
     comment = _create_comment_field()
     video_link = VideoReplayLinkField(required=True)

--- a/project/thscoreboard/replays/lib/custom_fields.py
+++ b/project/thscoreboard/replays/lib/custom_fields.py
@@ -1,0 +1,26 @@
+"""Provide useful form fields."""
+
+from typing import Type
+
+from django import forms
+from django.db.models import enums
+
+
+class ChoicesEnumField(forms.TypedChoiceField):
+    """A field defined by a Django enum.
+
+    Unlike a regular ChoiceField, this field coerces values to match the
+    elements of the original Choices enum, rather than leaving them as
+    bare strings. This is useful when the value must be programmatically
+    manipulated after the fact.
+    """
+
+    def __init__(self, choices_class: Type[enums.Choices]):
+        def _Coerce(v):
+            for member in choices_class:
+                # Internally, TypedChoiceField casts values to strings.
+                if v == str(member.value):
+                    return member
+            raise ValueError(f"{v} cannot be coerced to a {choices_class}")
+
+        super().__init__(choices=choices_class.choices, coerce=_Coerce)

--- a/project/thscoreboard/replays/lib/test_custom_fields.py
+++ b/project/thscoreboard/replays/lib/test_custom_fields.py
@@ -1,0 +1,26 @@
+import unittest
+
+from django import forms
+from django.db.models import enums
+
+
+from replays.lib import custom_fields
+
+
+class SuitType(enums.IntegerChoices):
+    CLUBS = 1, "Clubs"
+    DIAMONDS = 2, "Diamonds"
+    HEARTS = 3, "Hearts"
+    SPADES = 4, "Spades"
+
+
+class TestForm(forms.Form):
+    suit = custom_fields.ChoicesEnumField(SuitType)
+
+
+class ChoicesEnumFieldTest(unittest.TestCase):
+    def testCoerces(self):
+        form = TestForm(data={"suit": 2})
+        form.is_valid()
+        self.assertEqual(form.cleaned_data["suit"], SuitType.DIAMONDS)
+        self.assertIsInstance(form.cleaned_data["suit"], SuitType)


### PR DESCRIPTION
The problem that caused me to write this PR is that enums get made available on Django forms as strings. This does work eventually; the string gets set on the model and is handled appropriately. But it's really annoying to work with programmatically. For example, equality checks fail in places you'd expect them to succeed.