### PR TITLE
Correct number of difficulties in th13

### DIFF
--- a/project/thscoreboard/replays/management/commands/setup_constant_tables.py
+++ b/project/thscoreboard/replays/management/commands/setup_constant_tables.py
@@ -110,7 +110,7 @@ th14 = GameConstants(
 th13 = GameConstants(
     id="th13",
     has_replays=True,
-    num_difficulties=5,
+    num_difficulties=6,
     shots=["Reimu", "Marisa", "Sanae", "Youmu"],
     routes=[],
 )

--- a/project/thscoreboard/replays/views/replay_list.py
+++ b/project/thscoreboard/replays/views/replay_list.py
@@ -48,7 +48,7 @@ def game_scoreboard(
     game_id: str,
 ):
     game: Game = get_object_or_404(Game, game_id=game_id)
-    filter_options = _get_filter_options(game)
+    filter_options = get_filter_options(game)
     show_route = game_id in [
         game_ids.GameIDs.TH01,
         game_ids.GameIDs.TH08,
@@ -66,7 +66,7 @@ def game_scoreboard(
     )
 
 
-def _get_filter_options(game: Game) -> dict[str, list[str]]:
+def get_filter_options(game: Game) -> dict[str, list[str]]:
     if game.game_id == game_ids.GameIDs.TH01 or game.game_id == game_ids.GameIDs.TH128:
         return _get_filter_options_th01_th128(game)
     elif game.game_id == game_ids.GameIDs.TH08:

--- a/project/thscoreboard/replays/views/test_replay_list.py
+++ b/project/thscoreboard/replays/views/test_replay_list.py
@@ -1,5 +1,6 @@
 from django import test as django_test
 from django import urls
+from replays import models
 
 from replays import game_ids
 from replays.views import replay_list
@@ -35,3 +36,54 @@ class GameScoreboardRedirectTestCase(test_case.ReplayTestCase):
             response.url,
             urls.reverse("Replays/GameScoreboard", args=[game_ids.GameIDs.TH07]),
         )
+
+
+class GetFilterOptionsTestCase(test_case.ReplayTestCase):
+    def test_default(self):
+        game = models.Game.objects.get(game_id=game_ids.GameIDs.TH06)
+        filter_options = replay_list.get_filter_options(game)
+        self.assertCountEqual(filter_options.keys(), ("Difficulty", "Shot"))
+        self.assertEqual(len(filter_options["Difficulty"]), 5)
+        self.assertEqual(len(filter_options["Shot"]), 4)
+
+    def test_th01(self):
+        game = models.Game.objects.get(game_id=game_ids.GameIDs.TH01)
+        filter_options = replay_list.get_filter_options(game)
+        self.assertCountEqual(filter_options.keys(), ("Difficulty", "Route"))
+        self.assertEqual(len(filter_options["Difficulty"]), 4)
+        self.assertEqual(len(filter_options["Route"]), 2)
+
+    def test_th08(self):
+        game = models.Game.objects.get(game_id=game_ids.GameIDs.TH08)
+        filter_options = replay_list.get_filter_options(game)
+        self.assertCountEqual(filter_options.keys(), ("Difficulty", "Route", "Shot"))
+        self.assertEqual(len(filter_options["Difficulty"]), 5)
+        self.assertEqual(len(filter_options["Route"]), 2)
+        self.assertEqual(len(filter_options["Shot"]), 12)
+
+    def test_th13(self):
+        game = models.Game.objects.get(game_id=game_ids.GameIDs.TH13)
+        filter_options = replay_list.get_filter_options(game)
+        self.assertCountEqual(filter_options.keys(), ("Difficulty", "Shot"))
+        self.assertEqual(len(filter_options["Difficulty"]), 5)
+        self.assertEqual(len(filter_options["Shot"]), 4)
+
+    def test_th16(self):
+        game = models.Game.objects.get(game_id=game_ids.GameIDs.TH16)
+        filter_options = replay_list.get_filter_options(game)
+        self.assertCountEqual(
+            filter_options.keys(), ("Difficulty", "Character", "Season")
+        )
+        self.assertEqual(len(filter_options["Difficulty"]), 5)
+        self.assertEqual(len(filter_options["Season"]), 4)
+        self.assertEqual(len(filter_options["Season"]), 4)
+
+    def test_th17(self):
+        game = models.Game.objects.get(game_id=game_ids.GameIDs.TH17)
+        filter_options = replay_list.get_filter_options(game)
+        self.assertCountEqual(
+            filter_options.keys(), ("Difficulty", "Character", "Goast")
+        )
+        self.assertEqual(len(filter_options["Difficulty"]), 5)
+        self.assertEqual(len(filter_options["Character"]), 3)
+        self.assertEqual(len(filter_options["Goast"]), 3)


### PR DESCRIPTION
Currently, setup_constant_tables says that th13 has 5 difficulties, but it actually has 6 (Overdrive!). The code for fetching the filter options for th13 is broken as a result. This is why https://www.silentselene.net/replays/th13 is down.

After landing this, we need to run setup_constant_tables again on staging and production to fix the issue.

Fix: #493