### PR TITLE
Use the version of black we actually use in linter check, not "stable".

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@stable
+      - uses: psf/black@23.7.0
         with:
           src: "./project/thscoreboard"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@
 django-rosetta==0.9.9
 flake8==6.1.0
 python-dotenv==1.0.0
+# Remember to update .github/workflows/black.yml too if you update black.
 black==23.7.0


### PR DESCRIPTION
See for example:

https://github.com/n-rook/thscoreboard/actions/runs/7686845946/job/20946183725?pr=499

where the PR was rejected by the linter despite not actually changing any of the files it complains about. It's better to match the version in requirements-dev so this doesn't happen.