### PR TITLE
Appropriately format dates for JP locale.

### DIFF
--- a/project/thscoreboard/replays/lib/test_time.py
+++ b/project/thscoreboard/replays/lib/test_time.py
@@ -1,12 +1,41 @@
 import datetime
 import unittest
 
+from django import test
+
 from replays.lib import time
 
 
 class TimeTest(unittest.TestCase):
-    def testStrptime(self):
+    def test_strptime(self):
         parsed_time = time.strptime("11/24/2001", "%m/%d/%Y")
         self.assertEqual(
             parsed_time, datetime.datetime(2001, 11, 24, tzinfo=datetime.timezone.utc)
+        )
+
+    def test_format_date_ja(self):
+        self.enterContext(test.override_settings(LANGUAGE_CODE="ja"))
+        self.assertEqual(
+            time.format_date(datetime.datetime(year=2024, month=5, day=4)),
+            "2024年 5月 4日",
+        )
+
+    def test_format_date_en(self):
+        self.enterContext(test.override_settings(LANGUAGE_CODE="en"))
+        self.assertEqual(
+            time.format_date(datetime.datetime(year=2024, month=5, day=4)),
+            "04 May 2024",
+        )
+
+    def test_format_month_day_ja(self):
+        self.enterContext(test.override_settings(LANGUAGE_CODE="ja"))
+        self.assertEqual(
+            time.format_month_day(datetime.datetime(year=2024, month=5, day=4)), "5月 4日"
+        )
+
+    def test_format_month_day_en(self):
+        self.enterContext(test.override_settings(LANGUAGE_CODE="en"))
+        self.assertEqual(
+            time.format_month_day(datetime.datetime(year=2024, month=5, day=4)),
+            "04 May",
         )

--- a/project/thscoreboard/replays/lib/time.py
+++ b/project/thscoreboard/replays/lib/time.py
@@ -2,6 +2,9 @@
 
 import datetime
 
+from django.utils import formats
+from django.utils import translation
+
 
 def strptime(date_string: str, format: str) -> datetime.datetime:
     """Returns a datetime created from a string input.
@@ -12,3 +15,21 @@ def strptime(date_string: str, format: str) -> datetime.datetime:
     return datetime.datetime.strptime(date_string, format).replace(
         tzinfo=datetime.timezone.utc
     )
+
+
+def format_month_day(timestamp: datetime.date | datetime.datetime | str) -> str:
+    """Format a date, including only the month and day."""
+    if translation.get_language() == "ja":
+        f = "n月 j日"
+    else:  # en
+        f = "d F"
+    return formats.date_format(timestamp, format=f)
+
+
+def format_date(timestamp: datetime.date | datetime.datetime | str) -> str:
+    """Format a date."""
+    if translation.get_language() == "ja":
+        f = "Y年 n月 j日"
+    else:  # en
+        f = "d F Y"
+    return formats.date_format(timestamp, format=f)

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from django.db import models
 from django.db import utils
-from django.utils import formats
 from django.utils import timezone
 from django.utils.translation import pgettext_lazy
 from django.db.models import Q, QuerySet

--- a/project/thscoreboard/replays/models.py
+++ b/project/thscoreboard/replays/models.py
@@ -14,6 +14,7 @@ from django.db.models import Q, QuerySet
 from replays import game_ids
 from replays import limits
 from replays import replay_parsing
+from replays.lib import time as time_lib
 from shared_content import db_errors
 from shared_content import model_ttl
 from thscoreboard import settings
@@ -449,11 +450,9 @@ class Replay(models.Model):
             return None
 
         if self.shot.game_id == game_ids.GameIDs.TH07:
-            fmt = "d F"
+            return time_lib.format_month_day(self.timestamp)
         else:
-            fmt = "d F Y"
-
-        return formats.date_format(self.timestamp, format=fmt)
+            return time_lib.format_date(self.timestamp)
 
 
 class ReplayRank(models.Model):


### PR DESCRIPTION
Fixes #524. (At least, I think this is the only place the date was overridden in this weird way.)
<img width="432" alt="Screenshot 2025-05-10 at 4 58 27 PM" src="https://github.com/user-attachments/assets/f702a486-9755-4c6d-95cc-79d2f71acf8b" />
